### PR TITLE
Read/write all register fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+embedded-hal = "1.0.0-rc.1"
+bitfield = "0.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1420,6 +1420,27 @@ where
         self.write_deviceid(new_value)
     }
 
+    /// Read the *DAC Dither register* contents
+    pub fn read_dacdither(&mut self) -> Result<registers::DacDither, Error<I::Error>> {
+        let value = self.read_register(Register::DacDither)?;
+        Ok(registers::DacDither(value))
+    }
+
+    /// Write the *DAC Dither register* contents
+    pub fn write_dacdither(&mut self, value: registers::DacDither) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::DacDither, value.0)
+    }
+
+    /// Modify the *DAC Dither register* contents
+    pub fn modify_dacdither<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::DacDither) -> registers::DacDither,
+    {
+        let value = self.read_dacdither()?;
+        let new_value = f(value);
+        self.write_dacdither(new_value)
+    }
+
     /// Read the *ALC Enhancements 1 register* contents
     pub fn read_alcenhancements1(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,1714 @@
 //! A driver for the register interface on the Nuvoton NAU88C22 CODEC
 //!
-//! Works in I2C mode only, for now.
+//! Works in I²C mode only, for now.
 
 // SPDX-FileCopyrightText: 2023 Jonathan 'theJPster' Pallant <github@thejpster.org.uk>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![no_std]
+#![deny(missing_docs)]
+
+pub mod registers;
+
+use embedded_hal::i2c::{I2c, SevenBitAddress};
+
+#[doc(inline)]
+pub use registers::Register;
+
+/// Represents the NAU882CC CODEC
+///
+/// All methods change the CODEC settings in real-time.
+///
+/// In general, for every register *Foo* there is:
+///
+/// * A type `struct Foo`, with methods to read and write the fields within it
+/// * A method `fn read_foo(&mut self) -> Result<Foo, Error>`
+/// * A method `fn write_foo(&mut self, value: Foo) -> Result<(), Error>`
+/// * A method `fn modify_foo<F>(&mut self, f: F) -> Result<(), Error> where F: FnOnce(Foo) -> Foo`
+#[derive(Debug, Clone)]
+pub struct Codec<I> {
+    interface: I,
+    external_freq: Option<u32>,
+}
+
+/// Represents the ways that this library can fail
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error<E> {
+    /// An I2C Error occurred
+    I2c(E),
+    /// The wrong Device ID was returned
+    WrongDeviceId,
+}
+
+impl<E> From<E> for Error<E> {
+    fn from(value: E) -> Self {
+        Error::I2c(value)
+    }
+}
+
+impl<I> Codec<I>
+where
+    I: I2c,
+{
+    /// Our I2C device address
+    const DEVICE_ADDR: SevenBitAddress = 0b0011010;
+    /// Expected in the Device ID register
+    const DEVICE_ID: u16 = 0x1A;
+
+    /// Create a new CODEC object.
+    ///
+    /// Holds on to the given I²C interface so it can perform I²C transactions
+    /// whenever its methods are called.
+    ///
+    /// Pass it the external frequency provided on the MCLK pin, if any. This
+    /// will be used in PLL calculations.
+    pub const fn new(interface: I, external_freq: Option<u32>) -> Codec<I> {
+        Codec {
+            interface,
+            external_freq,
+        }
+    }
+
+    /// Read the Device ID register as a check we actually have a CODEC
+    pub fn check_device_id(&mut self) -> Result<(), Error<I::Error>> {
+        let device_id = self.read_register(Register::DeviceId)?;
+        if device_id == Self::DEVICE_ID {
+            Ok(())
+        } else {
+            Err(Error::WrongDeviceId)
+        }
+    }
+
+    /// Reset the chip
+    pub fn reset(&mut self) -> Result<(), Error<I::Error>> {
+        // write anything to this register to reset it
+        self.write_register(Register::SoftwareReset, 0x1FF)
+    }
+
+    /// Read the *Power Management 1 register* contents
+    pub fn read_powermanagement1(
+        &mut self,
+    ) -> Result<registers::PowerManagement1, Error<I::Error>> {
+        let value = self.read_register(Register::PowerManagement1)?;
+        Ok(registers::PowerManagement1(value))
+    }
+
+    /// Write the *Power Management 1 register* contents
+    pub fn write_powermanagement1(
+        &mut self,
+        value: registers::PowerManagement1,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::PowerManagement1, value.0)
+    }
+
+    /// Modify the *Power Management 1 register* contents
+    pub fn modify_powermanagement1<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::PowerManagement1) -> registers::PowerManagement1,
+    {
+        let value = self.read_powermanagement1()?;
+        let new_value = f(value);
+        self.write_powermanagement1(new_value)
+    }
+
+    /// Read the *Power Management 2 register* contents
+    pub fn read_powermanagement2(
+        &mut self,
+    ) -> Result<registers::PowerManagement2, Error<I::Error>> {
+        let value = self.read_register(Register::PowerManagement2)?;
+        Ok(registers::PowerManagement2(value))
+    }
+
+    /// Write the *Power Management 2 register* contents
+    pub fn write_powermanagement2(
+        &mut self,
+        value: registers::PowerManagement2,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::PowerManagement2, value.0)
+    }
+
+    /// Modify the *Power Management 2 register* contents
+    pub fn modify_powermanagement2<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::PowerManagement2) -> registers::PowerManagement2,
+    {
+        let value = self.read_powermanagement2()?;
+        let new_value = f(value);
+        self.write_powermanagement2(new_value)
+    }
+
+    /// Read the *Power Management 3 register* contents
+    pub fn read_powermanagement3(
+        &mut self,
+    ) -> Result<registers::PowerManagement3, Error<I::Error>> {
+        let value = self.read_register(Register::PowerManagement3)?;
+        Ok(registers::PowerManagement3(value))
+    }
+
+    /// Write the *Power Management 3 register* contents
+    pub fn write_powermanagement3(
+        &mut self,
+        value: registers::PowerManagement3,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::PowerManagement3, value.0)
+    }
+
+    /// Modify the *Power Management 3 register* contents
+    pub fn modify_powermanagement3<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::PowerManagement3) -> registers::PowerManagement3,
+    {
+        let value = self.read_powermanagement3()?;
+        let new_value = f(value);
+        self.write_powermanagement3(new_value)
+    }
+
+    /// Read the *Audio Interface register* contents
+    pub fn read_audiointerface(&mut self) -> Result<registers::AudioInterface, Error<I::Error>> {
+        let value = self.read_register(Register::AudioInterface)?;
+        Ok(registers::AudioInterface(value))
+    }
+
+    /// Write the *Audio Interface register* contents
+    pub fn write_audiointerface(
+        &mut self,
+        value: registers::AudioInterface,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::AudioInterface, value.0)
+    }
+
+    /// Modify the *Audio Interface register* contents
+    pub fn modify_audiointerface<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::AudioInterface) -> registers::AudioInterface,
+    {
+        let value = self.read_audiointerface()?;
+        let new_value = f(value);
+        self.write_audiointerface(new_value)
+    }
+
+    /// Read the *Companding register* contents
+    pub fn read_companding(&mut self) -> Result<registers::Companding, Error<I::Error>> {
+        let value = self.read_register(Register::Companding)?;
+        Ok(registers::Companding(value))
+    }
+
+    /// Write the *Companding register* contents
+    pub fn write_companding(
+        &mut self,
+        value: registers::Companding,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::Companding, value.0)
+    }
+
+    /// Modify the *Companding register* contents
+    pub fn modify_companding<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::Companding) -> registers::Companding,
+    {
+        let value = self.read_companding()?;
+        let new_value = f(value);
+        self.write_companding(new_value)
+    }
+
+    /// Read the *Clock Control 1 register* contents
+    pub fn read_clockcontrol1(&mut self) -> Result<registers::ClockControl1, Error<I::Error>> {
+        let value = self.read_register(Register::ClockControl1)?;
+        Ok(registers::ClockControl1(value))
+    }
+
+    /// Write the *Clock Control 1 register* contents
+    pub fn write_clockcontrol1(
+        &mut self,
+        value: registers::ClockControl1,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::ClockControl1, value.0)
+    }
+
+    /// Modify the *Clock Control 1 register* contents
+    pub fn modify_clockcontrol1<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::ClockControl1) -> registers::ClockControl1,
+    {
+        let value = self.read_clockcontrol1()?;
+        let new_value = f(value);
+        self.write_clockcontrol1(new_value)
+    }
+
+    /// Read the *Clock Control 2 register* contents
+    pub fn read_clockcontrol2(&mut self) -> Result<registers::ClockControl2, Error<I::Error>> {
+        let value = self.read_register(Register::ClockControl2)?;
+        Ok(registers::ClockControl2(value))
+    }
+
+    /// Write the *Clock Control 2 register* contents
+    pub fn write_clockcontrol2(
+        &mut self,
+        value: registers::ClockControl2,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::ClockControl2, value.0)
+    }
+
+    /// Modify the *Clock Control 2 register* contents
+    pub fn modify_clockcontrol2<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::ClockControl2) -> registers::ClockControl2,
+    {
+        let value = self.read_clockcontrol2()?;
+        let new_value = f(value);
+        self.write_clockcontrol2(new_value)
+    }
+
+    /// Read the *GPIO register* contents
+    pub fn read_gpio(&mut self) -> Result<registers::GPIO, Error<I::Error>> {
+        let value = self.read_register(Register::GPIO)?;
+        Ok(registers::GPIO(value))
+    }
+
+    /// Write the *GPIO register* contents
+    pub fn write_gpio(&mut self, value: registers::GPIO) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::GPIO, value.0)
+    }
+
+    /// Modify the *GPIO register* contents
+    pub fn modify_gpio<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::GPIO) -> registers::GPIO,
+    {
+        let value = self.read_gpio()?;
+        let new_value = f(value);
+        self.write_gpio(new_value)
+    }
+
+    /// Read the *Jack Detect 1 register* contents
+    pub fn read_jackdetect1(&mut self) -> Result<registers::JackDetect1, Error<I::Error>> {
+        let value = self.read_register(Register::JackDetect1)?;
+        Ok(registers::JackDetect1(value))
+    }
+
+    /// Write the *Jack Detect 1 register* contents
+    pub fn write_jackdetect1(
+        &mut self,
+        value: registers::JackDetect1,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::JackDetect1, value.0)
+    }
+
+    /// Modify the *Jack Detect 1 register* contents
+    pub fn modify_jackdetect1<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::JackDetect1) -> registers::JackDetect1,
+    {
+        let value = self.read_jackdetect1()?;
+        let new_value = f(value);
+        self.write_jackdetect1(new_value)
+    }
+
+    /// Read the *DAC Control register* contents
+    pub fn read_daccontrol(&mut self) -> Result<registers::DACControl, Error<I::Error>> {
+        let value = self.read_register(Register::DACControl)?;
+        Ok(registers::DACControl(value))
+    }
+
+    /// Write the *DAC Control register* contents
+    pub fn write_daccontrol(
+        &mut self,
+        value: registers::DACControl,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::DACControl, value.0)
+    }
+
+    /// Modify the *DAC Control register* contents
+    pub fn modify_daccontrol<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::DACControl) -> registers::DACControl,
+    {
+        let value = self.read_daccontrol()?;
+        let new_value = f(value);
+        self.write_daccontrol(new_value)
+    }
+
+    /// Read the *Left DAC Volume register* contents
+    pub fn read_leftdacvolume(&mut self) -> Result<registers::LeftDACVolume, Error<I::Error>> {
+        let value = self.read_register(Register::LeftDACVolume)?;
+        Ok(registers::LeftDACVolume(value))
+    }
+
+    /// Write the *Left DAC Volume register* contents
+    pub fn write_leftdacvolume(
+        &mut self,
+        value: registers::LeftDACVolume,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::LeftDACVolume, value.0)
+    }
+
+    /// Modify the *Left DAC Volume register* contents
+    pub fn modify_leftdacvolume<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::LeftDACVolume) -> registers::LeftDACVolume,
+    {
+        let value = self.read_leftdacvolume()?;
+        let new_value = f(value);
+        self.write_leftdacvolume(new_value)
+    }
+
+    /// Read the *Right DAC Volume register* contents
+    pub fn read_rightdacvolume(&mut self) -> Result<registers::RightDACVolume, Error<I::Error>> {
+        let value = self.read_register(Register::RightDACVolume)?;
+        Ok(registers::RightDACVolume(value))
+    }
+
+    /// Write the *Right DAC Volume register* contents
+    pub fn write_rightdacvolume(
+        &mut self,
+        value: registers::RightDACVolume,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::RightDACVolume, value.0)
+    }
+
+    /// Modify the *Right DAC Volume register* contents
+    pub fn modify_rightdacvolume<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::RightDACVolume) -> registers::RightDACVolume,
+    {
+        let value = self.read_rightdacvolume()?;
+        let new_value = f(value);
+        self.write_rightdacvolume(new_value)
+    }
+
+    /// Read the *Jack Detect 2 register* contents
+    pub fn read_jackdetect2(&mut self) -> Result<registers::JackDetect2, Error<I::Error>> {
+        let value = self.read_register(Register::JackDetect2)?;
+        Ok(registers::JackDetect2(value))
+    }
+
+    /// Write the *Jack Detect 2 register* contents
+    pub fn write_jackdetect2(
+        &mut self,
+        value: registers::JackDetect2,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::JackDetect2, value.0)
+    }
+
+    /// Modify the *Jack Detect 2 register* contents
+    pub fn modify_jackdetect2<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::JackDetect2) -> registers::JackDetect2,
+    {
+        let value = self.read_jackdetect2()?;
+        let new_value = f(value);
+        self.write_jackdetect2(new_value)
+    }
+
+    /// Read the *ADC Control register* contents
+    pub fn read_adccontrol(&mut self) -> Result<registers::ADCControl, Error<I::Error>> {
+        let value = self.read_register(Register::ADCControl)?;
+        Ok(registers::ADCControl(value))
+    }
+
+    /// Write the *ADC Control register* contents
+    pub fn write_adccontrol(
+        &mut self,
+        value: registers::ADCControl,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::ADCControl, value.0)
+    }
+
+    /// Modify the *ADC Control register* contents
+    pub fn modify_adccontrol<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::ADCControl) -> registers::ADCControl,
+    {
+        let value = self.read_adccontrol()?;
+        let new_value = f(value);
+        self.write_adccontrol(new_value)
+    }
+
+    /// Read the *Left ADC Volume register* contents
+    pub fn read_leftadcvolume(&mut self) -> Result<registers::LeftADCVolume, Error<I::Error>> {
+        let value = self.read_register(Register::LeftADCVolume)?;
+        Ok(registers::LeftADCVolume(value))
+    }
+
+    /// Write the *Left ADC Volume register* contents
+    pub fn write_leftadcvolume(
+        &mut self,
+        value: registers::LeftADCVolume,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::LeftADCVolume, value.0)
+    }
+
+    /// Modify the *Left ADC Volume register* contents
+    pub fn modify_leftadcvolume<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::LeftADCVolume) -> registers::LeftADCVolume,
+    {
+        let value = self.read_leftadcvolume()?;
+        let new_value = f(value);
+        self.write_leftadcvolume(new_value)
+    }
+
+    /// Read the *Right ADC Volume register* contents
+    pub fn read_rightadcvolume(&mut self) -> Result<registers::RightADCVolume, Error<I::Error>> {
+        let value = self.read_register(Register::RightADCVolume)?;
+        Ok(registers::RightADCVolume(value))
+    }
+
+    /// Write the *Right ADC Volume register* contents
+    pub fn write_rightadcvolume(
+        &mut self,
+        value: registers::RightADCVolume,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::RightADCVolume, value.0)
+    }
+
+    /// Modify the *Right ADC Volume register* contents
+    pub fn modify_rightadcvolume<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::RightADCVolume) -> registers::RightADCVolume,
+    {
+        let value = self.read_rightadcvolume()?;
+        let new_value = f(value);
+        self.write_rightadcvolume(new_value)
+    }
+
+    /// Read the *EQ1-high cutoff register* contents
+    pub fn read_eq1highcutoff(&mut self) -> Result<registers::EQ1HighCutoff, Error<I::Error>> {
+        let value = self.read_register(Register::EQ1HighCutoff)?;
+        Ok(registers::EQ1HighCutoff(value))
+    }
+
+    /// Write the *EQ1-high cutoff register* contents
+    pub fn write_eq1highcutoff(
+        &mut self,
+        value: registers::EQ1HighCutoff,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::EQ1HighCutoff, value.0)
+    }
+
+    /// Modify the *EQ1-high cutoff register* contents
+    pub fn modify_eq1highcutoff<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::EQ1HighCutoff) -> registers::EQ1HighCutoff,
+    {
+        let value = self.read_eq1highcutoff()?;
+        let new_value = f(value);
+        self.write_eq1highcutoff(new_value)
+    }
+
+    /// Read the *EQ2-peak 1 register* contents
+    pub fn read_eq2peak1(&mut self) -> Result<registers::EQ2Peak1, Error<I::Error>> {
+        let value = self.read_register(Register::EQ2Peak1)?;
+        Ok(registers::EQ2Peak1(value))
+    }
+
+    /// Write the *EQ2-peak 1 register* contents
+    pub fn write_eq2peak1(&mut self, value: registers::EQ2Peak1) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::EQ2Peak1, value.0)
+    }
+
+    /// Modify the *EQ2-peak 1 register* contents
+    pub fn modify_eq2peak1<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::EQ2Peak1) -> registers::EQ2Peak1,
+    {
+        let value = self.read_eq2peak1()?;
+        let new_value = f(value);
+        self.write_eq2peak1(new_value)
+    }
+
+    /// Read the *EQ3-peak 2 register* contents
+    pub fn read_eq3peak2(&mut self) -> Result<registers::EQ3Peak2, Error<I::Error>> {
+        let value = self.read_register(Register::EQ3Peak2)?;
+        Ok(registers::EQ3Peak2(value))
+    }
+
+    /// Write the *EQ3-peak 2 register* contents
+    pub fn write_eq3peak2(&mut self, value: registers::EQ3Peak2) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::EQ3Peak2, value.0)
+    }
+
+    /// Modify the *EQ3-peak 2 register* contents
+    pub fn modify_eq3peak2<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::EQ3Peak2) -> registers::EQ3Peak2,
+    {
+        let value = self.read_eq3peak2()?;
+        let new_value = f(value);
+        self.write_eq3peak2(new_value)
+    }
+
+    /// Read the *EQ4-peak 3 register* contents
+    pub fn read_eq4peak3(&mut self) -> Result<registers::EQ4Peak3, Error<I::Error>> {
+        let value = self.read_register(Register::EQ4Peak3)?;
+        Ok(registers::EQ4Peak3(value))
+    }
+
+    /// Write the *EQ4-peak 3 register* contents
+    pub fn write_eq4peak3(&mut self, value: registers::EQ4Peak3) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::EQ4Peak3, value.0)
+    }
+
+    /// Modify the *EQ4-peak 3 register* contents
+    pub fn modify_eq4peak3<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::EQ4Peak3) -> registers::EQ4Peak3,
+    {
+        let value = self.read_eq4peak3()?;
+        let new_value = f(value);
+        self.write_eq4peak3(new_value)
+    }
+
+    /// Read the *EQ5-low cutoff register* contents
+    pub fn read_eq5lowcutoff(&mut self) -> Result<registers::EQ5LowCutoff, Error<I::Error>> {
+        let value = self.read_register(Register::EQ5LowCutoff)?;
+        Ok(registers::EQ5LowCutoff(value))
+    }
+
+    /// Write the *EQ5-low cutoff register* contents
+    pub fn write_eq5lowcutoff(
+        &mut self,
+        value: registers::EQ5LowCutoff,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::EQ5LowCutoff, value.0)
+    }
+
+    /// Modify the *EQ5-low cutoff register* contents
+    pub fn modify_eq5lowcutoff<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::EQ5LowCutoff) -> registers::EQ5LowCutoff,
+    {
+        let value = self.read_eq5lowcutoff()?;
+        let new_value = f(value);
+        self.write_eq5lowcutoff(new_value)
+    }
+
+    /// Read the *DAC Limiter 1 register* contents
+    pub fn read_daclimiter1(&mut self) -> Result<registers::DACLimiter1, Error<I::Error>> {
+        let value = self.read_register(Register::DACLimiter1)?;
+        Ok(registers::DACLimiter1(value))
+    }
+
+    /// Write the *DAC Limiter 1 register* contents
+    pub fn write_daclimiter1(
+        &mut self,
+        value: registers::DACLimiter1,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::DACLimiter1, value.0)
+    }
+
+    /// Modify the *DAC Limiter 1 register* contents
+    pub fn modify_daclimiter1<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::DACLimiter1) -> registers::DACLimiter1,
+    {
+        let value = self.read_daclimiter1()?;
+        let new_value = f(value);
+        self.write_daclimiter1(new_value)
+    }
+
+    /// Read the *DAC Limiter 2 register* contents
+    pub fn read_daclimiter2(&mut self) -> Result<registers::DACLimiter2, Error<I::Error>> {
+        let value = self.read_register(Register::DACLimiter2)?;
+        Ok(registers::DACLimiter2(value))
+    }
+
+    /// Write the *DAC Limiter 2 register* contents
+    pub fn write_daclimiter2(
+        &mut self,
+        value: registers::DACLimiter2,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::DACLimiter2, value.0)
+    }
+
+    /// Modify the *DAC Limiter 2 register* contents
+    pub fn modify_daclimiter2<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::DACLimiter2) -> registers::DACLimiter2,
+    {
+        let value = self.read_daclimiter2()?;
+        let new_value = f(value);
+        self.write_daclimiter2(new_value)
+    }
+
+    /// Read the *Notch Filter 1 register* contents
+    pub fn read_notchfilter1(&mut self) -> Result<registers::NotchFilter1, Error<I::Error>> {
+        let value = self.read_register(Register::NotchFilter1)?;
+        Ok(registers::NotchFilter1(value))
+    }
+
+    /// Write the *Notch Filter 1 register* contents
+    pub fn write_notchfilter1(
+        &mut self,
+        value: registers::NotchFilter1,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::NotchFilter1, value.0)
+    }
+
+    /// Modify the *Notch Filter 1 register* contents
+    pub fn modify_notchfilter1<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::NotchFilter1) -> registers::NotchFilter1,
+    {
+        let value = self.read_notchfilter1()?;
+        let new_value = f(value);
+        self.write_notchfilter1(new_value)
+    }
+
+    /// Read the *Notch Filter 2 register* contents
+    pub fn read_notchfilter2(&mut self) -> Result<registers::NotchFilter2, Error<I::Error>> {
+        let value = self.read_register(Register::NotchFilter2)?;
+        Ok(registers::NotchFilter2(value))
+    }
+
+    /// Write the *Notch Filter 2 register* contents
+    pub fn write_notchfilter2(
+        &mut self,
+        value: registers::NotchFilter2,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::NotchFilter2, value.0)
+    }
+
+    /// Modify the *Notch Filter 2 register* contents
+    pub fn modify_notchfilter2<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::NotchFilter2) -> registers::NotchFilter2,
+    {
+        let value = self.read_notchfilter2()?;
+        let new_value = f(value);
+        self.write_notchfilter2(new_value)
+    }
+
+    /// Read the *Notch Filter 3 register* contents
+    pub fn read_notchfilter3(&mut self) -> Result<registers::NotchFilter3, Error<I::Error>> {
+        let value = self.read_register(Register::NotchFilter3)?;
+        Ok(registers::NotchFilter3(value))
+    }
+
+    /// Write the *Notch Filter 3 register* contents
+    pub fn write_notchfilter3(
+        &mut self,
+        value: registers::NotchFilter3,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::NotchFilter3, value.0)
+    }
+
+    /// Modify the *Notch Filter 3 register* contents
+    pub fn modify_notchfilter3<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::NotchFilter3) -> registers::NotchFilter3,
+    {
+        let value = self.read_notchfilter3()?;
+        let new_value = f(value);
+        self.write_notchfilter3(new_value)
+    }
+
+    /// Read the *Notch Filter 4 register* contents
+    pub fn read_notchfilter4(&mut self) -> Result<registers::NotchFilter4, Error<I::Error>> {
+        let value = self.read_register(Register::NotchFilter4)?;
+        Ok(registers::NotchFilter4(value))
+    }
+
+    /// Write the *Notch Filter 4 register* contents
+    pub fn write_notchfilter4(
+        &mut self,
+        value: registers::NotchFilter4,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::NotchFilter4, value.0)
+    }
+
+    /// Modify the *Notch Filter 4 register* contents
+    pub fn modify_notchfilter4<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::NotchFilter4) -> registers::NotchFilter4,
+    {
+        let value = self.read_notchfilter4()?;
+        let new_value = f(value);
+        self.write_notchfilter4(new_value)
+    }
+
+    /// Read the *ALC Control 1 register* contents
+    pub fn read_alccontrol1(&mut self) -> Result<registers::ALCControl1, Error<I::Error>> {
+        let value = self.read_register(Register::ALCControl1)?;
+        Ok(registers::ALCControl1(value))
+    }
+
+    /// Write the *ALC Control 1 register* contents
+    pub fn write_alccontrol1(
+        &mut self,
+        value: registers::ALCControl1,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::ALCControl1, value.0)
+    }
+
+    /// Modify the *ALC Control 1 register* contents
+    pub fn modify_alccontrol1<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::ALCControl1) -> registers::ALCControl1,
+    {
+        let value = self.read_alccontrol1()?;
+        let new_value = f(value);
+        self.write_alccontrol1(new_value)
+    }
+
+    /// Read the *ALC Control 2 register* contents
+    pub fn read_alccontrol2(&mut self) -> Result<registers::ALCControl2, Error<I::Error>> {
+        let value = self.read_register(Register::ALCControl2)?;
+        Ok(registers::ALCControl2(value))
+    }
+
+    /// Write the *ALC Control 2 register* contents
+    pub fn write_alccontrol2(
+        &mut self,
+        value: registers::ALCControl2,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::ALCControl2, value.0)
+    }
+
+    /// Modify the *ALC Control 2 register* contents
+    pub fn modify_alccontrol2<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::ALCControl2) -> registers::ALCControl2,
+    {
+        let value = self.read_alccontrol2()?;
+        let new_value = f(value);
+        self.write_alccontrol2(new_value)
+    }
+
+    /// Read the *ALC Control 3 register* contents
+    pub fn read_alccontrol3(&mut self) -> Result<registers::ALCControl3, Error<I::Error>> {
+        let value = self.read_register(Register::ALCControl3)?;
+        Ok(registers::ALCControl3(value))
+    }
+
+    /// Write the *ALC Control 3 register* contents
+    pub fn write_alccontrol3(
+        &mut self,
+        value: registers::ALCControl3,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::ALCControl3, value.0)
+    }
+
+    /// Modify the *ALC Control 3 register* contents
+    pub fn modify_alccontrol3<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::ALCControl3) -> registers::ALCControl3,
+    {
+        let value = self.read_alccontrol3()?;
+        let new_value = f(value);
+        self.write_alccontrol3(new_value)
+    }
+
+    /// Read the *Noise Gate register* contents
+    pub fn read_noisegate(&mut self) -> Result<registers::NoiseGate, Error<I::Error>> {
+        let value = self.read_register(Register::NoiseGate)?;
+        Ok(registers::NoiseGate(value))
+    }
+
+    /// Write the *Noise Gate register* contents
+    pub fn write_noisegate(&mut self, value: registers::NoiseGate) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::NoiseGate, value.0)
+    }
+
+    /// Modify the *Noise Gate register* contents
+    pub fn modify_noisegate<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::NoiseGate) -> registers::NoiseGate,
+    {
+        let value = self.read_noisegate()?;
+        let new_value = f(value);
+        self.write_noisegate(new_value)
+    }
+
+    /// Read the *PLL N register* contents
+    pub fn read_plln(&mut self) -> Result<registers::PllN, Error<I::Error>> {
+        let value = self.read_register(Register::PllN)?;
+        Ok(registers::PllN(value))
+    }
+
+    /// Write the *PLL N register* contents
+    pub fn write_plln(&mut self, value: registers::PllN) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::PllN, value.0)
+    }
+
+    /// Modify the *PLL N register* contents
+    pub fn modify_plln<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::PllN) -> registers::PllN,
+    {
+        let value = self.read_plln()?;
+        let new_value = f(value);
+        self.write_plln(new_value)
+    }
+
+    /// Read the *PLL K 1 register* contents
+    pub fn read_pllk1(&mut self) -> Result<registers::PllK1, Error<I::Error>> {
+        let value = self.read_register(Register::PllK1)?;
+        Ok(registers::PllK1(value))
+    }
+
+    /// Write the *PLL K 1 register* contents
+    pub fn write_pllk1(&mut self, value: registers::PllK1) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::PllK1, value.0)
+    }
+
+    /// Modify the *PLL K 1 register* contents
+    pub fn modify_pllk1<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::PllK1) -> registers::PllK1,
+    {
+        let value = self.read_pllk1()?;
+        let new_value = f(value);
+        self.write_pllk1(new_value)
+    }
+
+    /// Read the *PLL K 2 register* contents
+    pub fn read_pllk2(&mut self) -> Result<registers::PllK2, Error<I::Error>> {
+        let value = self.read_register(Register::PllK2)?;
+        Ok(registers::PllK2(value))
+    }
+
+    /// Write the *PLL K 2 register* contents
+    pub fn write_pllk2(&mut self, value: registers::PllK2) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::PllK2, value.0)
+    }
+
+    /// Modify the *PLL K 2 register* contents
+    pub fn modify_pllk2<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::PllK2) -> registers::PllK2,
+    {
+        let value = self.read_pllk2()?;
+        let new_value = f(value);
+        self.write_pllk2(new_value)
+    }
+
+    /// Read the *PLL K 3 register* contents
+    pub fn read_pllk3(&mut self) -> Result<registers::PllK3, Error<I::Error>> {
+        let value = self.read_register(Register::PllK3)?;
+        Ok(registers::PllK3(value))
+    }
+
+    /// Write the *PLL K 3 register* contents
+    pub fn write_pllk3(&mut self, value: registers::PllK3) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::PllK3, value.0)
+    }
+
+    /// Modify the *PLL K 3 register* contents
+    pub fn modify_pllk3<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::PllK3) -> registers::PllK3,
+    {
+        let value = self.read_pllk3()?;
+        let new_value = f(value);
+        self.write_pllk3(new_value)
+    }
+
+    /// Read the *3D control register* contents
+    pub fn read_threedcontrol(&mut self) -> Result<registers::ThreeDControl, Error<I::Error>> {
+        let value = self.read_register(Register::ThreeDControl)?;
+        Ok(registers::ThreeDControl(value))
+    }
+
+    /// Write the *3D control register* contents
+    pub fn write_threedcontrol(
+        &mut self,
+        value: registers::ThreeDControl,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::ThreeDControl, value.0)
+    }
+
+    /// Modify the *3D control register* contents
+    pub fn modify_threedcontrol<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::ThreeDControl) -> registers::ThreeDControl,
+    {
+        let value = self.read_threedcontrol()?;
+        let new_value = f(value);
+        self.write_threedcontrol(new_value)
+    }
+
+    /// Read the *Right Speaker Submix register* contents
+    pub fn read_rightspeakersubmix(
+        &mut self,
+    ) -> Result<registers::RightSpeakerSubmix, Error<I::Error>> {
+        let value = self.read_register(Register::RightSpeakerSubmix)?;
+        Ok(registers::RightSpeakerSubmix(value))
+    }
+
+    /// Write the *Right Speaker Submix register* contents
+    pub fn write_rightspeakersubmix(
+        &mut self,
+        value: registers::RightSpeakerSubmix,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::RightSpeakerSubmix, value.0)
+    }
+
+    /// Modify the *Right Speaker Submix register* contents
+    pub fn modify_rightspeakersubmix<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::RightSpeakerSubmix) -> registers::RightSpeakerSubmix,
+    {
+        let value = self.read_rightspeakersubmix()?;
+        let new_value = f(value);
+        self.write_rightspeakersubmix(new_value)
+    }
+
+    /// Read the *Input Control register* contents
+    pub fn read_inputcontrol(&mut self) -> Result<registers::InputControl, Error<I::Error>> {
+        let value = self.read_register(Register::InputControl)?;
+        Ok(registers::InputControl(value))
+    }
+
+    /// Write the *Input Control register* contents
+    pub fn write_inputcontrol(
+        &mut self,
+        value: registers::InputControl,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::InputControl, value.0)
+    }
+
+    /// Modify the *Input Control register* contents
+    pub fn modify_inputcontrol<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::InputControl) -> registers::InputControl,
+    {
+        let value = self.read_inputcontrol()?;
+        let new_value = f(value);
+        self.write_inputcontrol(new_value)
+    }
+
+    /// Read the *Left Input PGA Gain register* contents
+    pub fn read_leftinputpgagain(
+        &mut self,
+    ) -> Result<registers::LeftInputPGAGain, Error<I::Error>> {
+        let value = self.read_register(Register::LeftInputPGAGain)?;
+        Ok(registers::LeftInputPGAGain(value))
+    }
+
+    /// Write the *Left Input PGA Gain register* contents
+    pub fn write_leftinputpgagain(
+        &mut self,
+        value: registers::LeftInputPGAGain,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::LeftInputPGAGain, value.0)
+    }
+
+    /// Modify the *Left Input PGA Gain register* contents
+    pub fn modify_leftinputpgagain<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::LeftInputPGAGain) -> registers::LeftInputPGAGain,
+    {
+        let value = self.read_leftinputpgagain()?;
+        let new_value = f(value);
+        self.write_leftinputpgagain(new_value)
+    }
+
+    /// Read the *Right Input PGA Gain register* contents
+    pub fn read_rightinputpgagain(
+        &mut self,
+    ) -> Result<registers::RightInputPGAGain, Error<I::Error>> {
+        let value = self.read_register(Register::RightInputPGAGain)?;
+        Ok(registers::RightInputPGAGain(value))
+    }
+
+    /// Write the *Right Input PGA Gain register* contents
+    pub fn write_rightinputpgagain(
+        &mut self,
+        value: registers::RightInputPGAGain,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::RightInputPGAGain, value.0)
+    }
+
+    /// Modify the *Right Input PGA Gain register* contents
+    pub fn modify_rightinputpgagain<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::RightInputPGAGain) -> registers::RightInputPGAGain,
+    {
+        let value = self.read_rightinputpgagain()?;
+        let new_value = f(value);
+        self.write_rightinputpgagain(new_value)
+    }
+
+    /// Read the *Left ADC Boost register* contents
+    pub fn read_leftadcboost(&mut self) -> Result<registers::LeftADCBoost, Error<I::Error>> {
+        let value = self.read_register(Register::LeftADCBoost)?;
+        Ok(registers::LeftADCBoost(value))
+    }
+
+    /// Write the *Left ADC Boost register* contents
+    pub fn write_leftadcboost(
+        &mut self,
+        value: registers::LeftADCBoost,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::LeftADCBoost, value.0)
+    }
+
+    /// Modify the *Left ADC Boost register* contents
+    pub fn modify_leftadcboost<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::LeftADCBoost) -> registers::LeftADCBoost,
+    {
+        let value = self.read_leftadcboost()?;
+        let new_value = f(value);
+        self.write_leftadcboost(new_value)
+    }
+
+    /// Read the *Right ADC Boost register* contents
+    pub fn read_rightadcboost(&mut self) -> Result<registers::RightADCBoost, Error<I::Error>> {
+        let value = self.read_register(Register::RightADCBoost)?;
+        Ok(registers::RightADCBoost(value))
+    }
+
+    /// Write the *Right ADC Boost register* contents
+    pub fn write_rightadcboost(
+        &mut self,
+        value: registers::RightADCBoost,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::RightADCBoost, value.0)
+    }
+
+    /// Modify the *Right ADC Boost register* contents
+    pub fn modify_rightadcboost<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::RightADCBoost) -> registers::RightADCBoost,
+    {
+        let value = self.read_rightadcboost()?;
+        let new_value = f(value);
+        self.write_rightadcboost(new_value)
+    }
+
+    /// Read the *Output Control register* contents
+    pub fn read_outputcontrol(&mut self) -> Result<registers::OutputControl, Error<I::Error>> {
+        let value = self.read_register(Register::OutputControl)?;
+        Ok(registers::OutputControl(value))
+    }
+
+    /// Write the *Output Control register* contents
+    pub fn write_outputcontrol(
+        &mut self,
+        value: registers::OutputControl,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::OutputControl, value.0)
+    }
+
+    /// Modify the *Output Control register* contents
+    pub fn modify_outputcontrol<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::OutputControl) -> registers::OutputControl,
+    {
+        let value = self.read_outputcontrol()?;
+        let new_value = f(value);
+        self.write_outputcontrol(new_value)
+    }
+
+    /// Read the *Left Mixer register* contents
+    pub fn read_leftmixer(&mut self) -> Result<registers::LeftMixer, Error<I::Error>> {
+        let value = self.read_register(Register::LeftMixer)?;
+        Ok(registers::LeftMixer(value))
+    }
+
+    /// Write the *Left Mixer register* contents
+    pub fn write_leftmixer(&mut self, value: registers::LeftMixer) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::LeftMixer, value.0)
+    }
+
+    /// Modify the *Left Mixer register* contents
+    pub fn modify_leftmixer<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::LeftMixer) -> registers::LeftMixer,
+    {
+        let value = self.read_leftmixer()?;
+        let new_value = f(value);
+        self.write_leftmixer(new_value)
+    }
+
+    /// Read the *Right Mixer register* contents
+    pub fn read_rightmixer(&mut self) -> Result<registers::RightMixer, Error<I::Error>> {
+        let value = self.read_register(Register::RightMixer)?;
+        Ok(registers::RightMixer(value))
+    }
+
+    /// Write the *Right Mixer register* contents
+    pub fn write_rightmixer(
+        &mut self,
+        value: registers::RightMixer,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::RightMixer, value.0)
+    }
+
+    /// Modify the *Right Mixer register* contents
+    pub fn modify_rightmixer<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::RightMixer) -> registers::RightMixer,
+    {
+        let value = self.read_rightmixer()?;
+        let new_value = f(value);
+        self.write_rightmixer(new_value)
+    }
+
+    /// Read the *LHP Volume register* contents
+    pub fn read_lhpvolume(&mut self) -> Result<registers::LHPVolume, Error<I::Error>> {
+        let value = self.read_register(Register::LHPVolume)?;
+        Ok(registers::LHPVolume(value))
+    }
+
+    /// Write the *LHP Volume register* contents
+    pub fn write_lhpvolume(&mut self, value: registers::LHPVolume) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::LHPVolume, value.0)
+    }
+
+    /// Modify the *LHP Volume register* contents
+    pub fn modify_lhpvolume<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::LHPVolume) -> registers::LHPVolume,
+    {
+        let value = self.read_lhpvolume()?;
+        let new_value = f(value);
+        self.write_lhpvolume(new_value)
+    }
+
+    /// Read the *RHP Volume register* contents
+    pub fn read_rhpvolume(&mut self) -> Result<registers::RHPVolume, Error<I::Error>> {
+        let value = self.read_register(Register::RHPVolume)?;
+        Ok(registers::RHPVolume(value))
+    }
+
+    /// Write the *RHP Volume register* contents
+    pub fn write_rhpvolume(&mut self, value: registers::RHPVolume) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::RHPVolume, value.0)
+    }
+
+    /// Modify the *RHP Volume register* contents
+    pub fn modify_rhpvolume<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::RHPVolume) -> registers::RHPVolume,
+    {
+        let value = self.read_rhpvolume()?;
+        let new_value = f(value);
+        self.write_rhpvolume(new_value)
+    }
+
+    /// Read the *LSPKOUT Volume register* contents
+    pub fn read_lspkoutvolume(&mut self) -> Result<registers::LSPKOUTVolume, Error<I::Error>> {
+        let value = self.read_register(Register::LSPKOUTVolume)?;
+        Ok(registers::LSPKOUTVolume(value))
+    }
+
+    /// Write the *LSPKOUT Volume register* contents
+    pub fn write_lspkoutvolume(
+        &mut self,
+        value: registers::LSPKOUTVolume,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::LSPKOUTVolume, value.0)
+    }
+
+    /// Modify the *LSPKOUT Volume register* contents
+    pub fn modify_lspkoutvolume<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::LSPKOUTVolume) -> registers::LSPKOUTVolume,
+    {
+        let value = self.read_lspkoutvolume()?;
+        let new_value = f(value);
+        self.write_lspkoutvolume(new_value)
+    }
+
+    /// Read the *RSPKOUT Volume register* contents
+    pub fn read_rspkoutvolume(&mut self) -> Result<registers::RSPKOUTVolume, Error<I::Error>> {
+        let value = self.read_register(Register::RSPKOUTVolume)?;
+        Ok(registers::RSPKOUTVolume(value))
+    }
+
+    /// Write the *RSPKOUT Volume register* contents
+    pub fn write_rspkoutvolume(
+        &mut self,
+        value: registers::RSPKOUTVolume,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::RSPKOUTVolume, value.0)
+    }
+
+    /// Modify the *RSPKOUT Volume register* contents
+    pub fn modify_rspkoutvolume<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::RSPKOUTVolume) -> registers::RSPKOUTVolume,
+    {
+        let value = self.read_rspkoutvolume()?;
+        let new_value = f(value);
+        self.write_rspkoutvolume(new_value)
+    }
+
+    /// Read the *AUX2 Mixer register* contents
+    pub fn read_aux2mixer(&mut self) -> Result<registers::AUX2Mixer, Error<I::Error>> {
+        let value = self.read_register(Register::AUX2Mixer)?;
+        Ok(registers::AUX2Mixer(value))
+    }
+
+    /// Write the *AUX2 Mixer register* contents
+    pub fn write_aux2mixer(&mut self, value: registers::AUX2Mixer) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::AUX2Mixer, value.0)
+    }
+
+    /// Modify the *AUX2 Mixer register* contents
+    pub fn modify_aux2mixer<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::AUX2Mixer) -> registers::AUX2Mixer,
+    {
+        let value = self.read_aux2mixer()?;
+        let new_value = f(value);
+        self.write_aux2mixer(new_value)
+    }
+
+    /// Read the *AUX1 Mixer register* contents
+    pub fn read_aux1mixer(&mut self) -> Result<registers::AUX1Mixer, Error<I::Error>> {
+        let value = self.read_register(Register::AUX1Mixer)?;
+        Ok(registers::AUX1Mixer(value))
+    }
+
+    /// Write the *AUX1 Mixer register* contents
+    pub fn write_aux1mixer(&mut self, value: registers::AUX1Mixer) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::AUX1Mixer, value.0)
+    }
+
+    /// Modify the *AUX1 Mixer register* contents
+    pub fn modify_aux1mixer<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::AUX1Mixer) -> registers::AUX1Mixer,
+    {
+        let value = self.read_aux1mixer()?;
+        let new_value = f(value);
+        self.write_aux1mixer(new_value)
+    }
+
+    /// Read the *Power Management register* contents
+    pub fn read_powermanagement(&mut self) -> Result<registers::PowerManagement, Error<I::Error>> {
+        let value = self.read_register(Register::PowerManagement)?;
+        Ok(registers::PowerManagement(value))
+    }
+
+    /// Write the *Power Management register* contents
+    pub fn write_powermanagement(
+        &mut self,
+        value: registers::PowerManagement,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::PowerManagement, value.0)
+    }
+
+    /// Modify the *Power Management register* contents
+    pub fn modify_powermanagement<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::PowerManagement) -> registers::PowerManagement,
+    {
+        let value = self.read_powermanagement()?;
+        let new_value = f(value);
+        self.write_powermanagement(new_value)
+    }
+
+    /// Read the *Left Time Slot register* contents
+    pub fn read_lefttimeslot(&mut self) -> Result<registers::LeftTimeSlot, Error<I::Error>> {
+        let value = self.read_register(Register::LeftTimeSlot)?;
+        Ok(registers::LeftTimeSlot(value))
+    }
+
+    /// Write the *Left Time Slot register* contents
+    pub fn write_lefttimeslot(
+        &mut self,
+        value: registers::LeftTimeSlot,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::LeftTimeSlot, value.0)
+    }
+
+    /// Modify the *Left Time Slot register* contents
+    pub fn modify_lefttimeslot<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::LeftTimeSlot) -> registers::LeftTimeSlot,
+    {
+        let value = self.read_lefttimeslot()?;
+        let new_value = f(value);
+        self.write_lefttimeslot(new_value)
+    }
+
+    /// Read the *Misc register* contents
+    pub fn read_misc(&mut self) -> Result<registers::Misc, Error<I::Error>> {
+        let value = self.read_register(Register::Misc)?;
+        Ok(registers::Misc(value))
+    }
+
+    /// Write the *Misc register* contents
+    pub fn write_misc(&mut self, value: registers::Misc) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::Misc, value.0)
+    }
+
+    /// Modify the *Misc register* contents
+    pub fn modify_misc<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::Misc) -> registers::Misc,
+    {
+        let value = self.read_misc()?;
+        let new_value = f(value);
+        self.write_misc(new_value)
+    }
+
+    /// Read the *Right Time Slot register* contents
+    pub fn read_righttimeslot(&mut self) -> Result<registers::RightTimeSlot, Error<I::Error>> {
+        let value = self.read_register(Register::RightTimeSlot)?;
+        Ok(registers::RightTimeSlot(value))
+    }
+
+    /// Write the *Right Time Slot register* contents
+    pub fn write_righttimeslot(
+        &mut self,
+        value: registers::RightTimeSlot,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::RightTimeSlot, value.0)
+    }
+
+    /// Modify the *Right Time Slot register* contents
+    pub fn modify_righttimeslot<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::RightTimeSlot) -> registers::RightTimeSlot,
+    {
+        let value = self.read_righttimeslot()?;
+        let new_value = f(value);
+        self.write_righttimeslot(new_value)
+    }
+
+    /// Read the *Device Revision # register* contents
+    pub fn read_devicerevisionno(
+        &mut self,
+    ) -> Result<registers::DeviceRevisionNo, Error<I::Error>> {
+        let value = self.read_register(Register::DeviceRevisionNo)?;
+        Ok(registers::DeviceRevisionNo(value))
+    }
+
+    /// Write the *Device Revision # register* contents
+    pub fn write_devicerevisionno(
+        &mut self,
+        value: registers::DeviceRevisionNo,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::DeviceRevisionNo, value.0)
+    }
+
+    /// Modify the *Device Revision # register* contents
+    pub fn modify_devicerevisionno<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::DeviceRevisionNo) -> registers::DeviceRevisionNo,
+    {
+        let value = self.read_devicerevisionno()?;
+        let new_value = f(value);
+        self.write_devicerevisionno(new_value)
+    }
+
+    /// Read the *Device ID register* contents
+    pub fn read_deviceid(&mut self) -> Result<registers::DeviceId, Error<I::Error>> {
+        let value = self.read_register(Register::DeviceId)?;
+        Ok(registers::DeviceId(value))
+    }
+
+    /// Write the *Device ID register* contents
+    pub fn write_deviceid(&mut self, value: registers::DeviceId) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::DeviceId, value.0)
+    }
+
+    /// Modify the *Device ID register* contents
+    pub fn modify_deviceid<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::DeviceId) -> registers::DeviceId,
+    {
+        let value = self.read_deviceid()?;
+        let new_value = f(value);
+        self.write_deviceid(new_value)
+    }
+
+    /// Read the *ALC Enhancements 1 register* contents
+    pub fn read_alcenhancements1(
+        &mut self,
+    ) -> Result<registers::AlcEnhancements1, Error<I::Error>> {
+        let value = self.read_register(Register::AlcEnhancements1)?;
+        Ok(registers::AlcEnhancements1(value))
+    }
+
+    /// Write the *ALC Enhancements 1 register* contents
+    pub fn write_alcenhancements1(
+        &mut self,
+        value: registers::AlcEnhancements1,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::AlcEnhancements1, value.0)
+    }
+
+    /// Modify the *ALC Enhancements 1 register* contents
+    pub fn modify_alcenhancements1<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::AlcEnhancements1) -> registers::AlcEnhancements1,
+    {
+        let value = self.read_alcenhancements1()?;
+        let new_value = f(value);
+        self.write_alcenhancements1(new_value)
+    }
+
+    /// Read the *ALC Enhancements 2 register* contents
+    pub fn read_alcenhancements2(
+        &mut self,
+    ) -> Result<registers::AlcEnhancements2, Error<I::Error>> {
+        let value = self.read_register(Register::AlcEnhancements2)?;
+        Ok(registers::AlcEnhancements2(value))
+    }
+
+    /// Write the *ALC Enhancements 2 register* contents
+    pub fn write_alcenhancements2(
+        &mut self,
+        value: registers::AlcEnhancements2,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::AlcEnhancements2, value.0)
+    }
+
+    /// Modify the *ALC Enhancements 2 register* contents
+    pub fn modify_alcenhancements2<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::AlcEnhancements2) -> registers::AlcEnhancements2,
+    {
+        let value = self.read_alcenhancements2()?;
+        let new_value = f(value);
+        self.write_alcenhancements2(new_value)
+    }
+
+    /// Read the *Misc Controls register* contents
+    pub fn read_misccontrols(&mut self) -> Result<registers::MiscControls, Error<I::Error>> {
+        let value = self.read_register(Register::MiscControls)?;
+        Ok(registers::MiscControls(value))
+    }
+
+    /// Write the *Misc Controls register* contents
+    pub fn write_misccontrols(
+        &mut self,
+        value: registers::MiscControls,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::MiscControls, value.0)
+    }
+
+    /// Modify the *Misc Controls register* contents
+    pub fn modify_misccontrols<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::MiscControls) -> registers::MiscControls,
+    {
+        let value = self.read_misccontrols()?;
+        let new_value = f(value);
+        self.write_misccontrols(new_value)
+    }
+
+    /// Read the *Tie-Off Overrides register* contents
+    pub fn read_tieoffoverrides(&mut self) -> Result<registers::TieOffOverrides, Error<I::Error>> {
+        let value = self.read_register(Register::TieOffOverrides)?;
+        Ok(registers::TieOffOverrides(value))
+    }
+
+    /// Write the *Tie-Off Overrides register* contents
+    pub fn write_tieoffoverrides(
+        &mut self,
+        value: registers::TieOffOverrides,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::TieOffOverrides, value.0)
+    }
+
+    /// Modify the *Tie-Off Overrides register* contents
+    pub fn modify_tieoffoverrides<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::TieOffOverrides) -> registers::TieOffOverrides,
+    {
+        let value = self.read_tieoffoverrides()?;
+        let new_value = f(value);
+        self.write_tieoffoverrides(new_value)
+    }
+
+    /// Read the *Power/Tie-off Ctrl register* contents
+    pub fn read_powertieoffctrl(&mut self) -> Result<registers::PowerTieOffCtrl, Error<I::Error>> {
+        let value = self.read_register(Register::PowerTieOffCtrl)?;
+        Ok(registers::PowerTieOffCtrl(value))
+    }
+
+    /// Write the *Power/Tie-off Ctrl register* contents
+    pub fn write_powertieoffctrl(
+        &mut self,
+        value: registers::PowerTieOffCtrl,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::PowerTieOffCtrl, value.0)
+    }
+
+    /// Modify the *Power/Tie-off Ctrl register* contents
+    pub fn modify_powertieoffctrl<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::PowerTieOffCtrl) -> registers::PowerTieOffCtrl,
+    {
+        let value = self.read_powertieoffctrl()?;
+        let new_value = f(value);
+        self.write_powertieoffctrl(new_value)
+    }
+
+    /// Read the *P2P Detector Read register* contents
+    pub fn read_p2pdetectorread(&mut self) -> Result<registers::P2PDetectorRead, Error<I::Error>> {
+        let value = self.read_register(Register::P2PDetectorRead)?;
+        Ok(registers::P2PDetectorRead(value))
+    }
+
+    /// Write the *P2P Detector Read register* contents
+    pub fn write_p2pdetectorread(
+        &mut self,
+        value: registers::P2PDetectorRead,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::P2PDetectorRead, value.0)
+    }
+
+    /// Modify the *P2P Detector Read register* contents
+    pub fn modify_p2pdetectorread<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::P2PDetectorRead) -> registers::P2PDetectorRead,
+    {
+        let value = self.read_p2pdetectorread()?;
+        let new_value = f(value);
+        self.write_p2pdetectorread(new_value)
+    }
+
+    /// Read the *Peak Detector Read register* contents
+    pub fn read_peakdetectorread(
+        &mut self,
+    ) -> Result<registers::PeakDetectorRead, Error<I::Error>> {
+        let value = self.read_register(Register::PeakDetectorRead)?;
+        Ok(registers::PeakDetectorRead(value))
+    }
+
+    /// Write the *Peak Detector Read register* contents
+    pub fn write_peakdetectorread(
+        &mut self,
+        value: registers::PeakDetectorRead,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::PeakDetectorRead, value.0)
+    }
+
+    /// Modify the *Peak Detector Read register* contents
+    pub fn modify_peakdetectorread<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::PeakDetectorRead) -> registers::PeakDetectorRead,
+    {
+        let value = self.read_peakdetectorread()?;
+        let new_value = f(value);
+        self.write_peakdetectorread(new_value)
+    }
+
+    /// Read the *Control and Status register* contents
+    pub fn read_controlandstatus(
+        &mut self,
+    ) -> Result<registers::ControlAndStatus, Error<I::Error>> {
+        let value = self.read_register(Register::ControlAndStatus)?;
+        Ok(registers::ControlAndStatus(value))
+    }
+
+    /// Write the *Control and Status register* contents
+    pub fn write_controlandstatus(
+        &mut self,
+        value: registers::ControlAndStatus,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::ControlAndStatus, value.0)
+    }
+
+    /// Modify the *Control and Status register* contents
+    pub fn modify_controlandstatus<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::ControlAndStatus) -> registers::ControlAndStatus,
+    {
+        let value = self.read_controlandstatus()?;
+        let new_value = f(value);
+        self.write_controlandstatus(new_value)
+    }
+
+    /// Read the *Output tie-off control register* contents
+    pub fn read_outputtieoffcontrol(
+        &mut self,
+    ) -> Result<registers::OutputTieOffControl, Error<I::Error>> {
+        let value = self.read_register(Register::OutputTieOffControl)?;
+        Ok(registers::OutputTieOffControl(value))
+    }
+
+    /// Write the *Output tie-off control register* contents
+    pub fn write_outputtieoffcontrol(
+        &mut self,
+        value: registers::OutputTieOffControl,
+    ) -> Result<(), Error<I::Error>> {
+        self.write_register(Register::OutputTieOffControl, value.0)
+    }
+
+    /// Modify the *Output tie-off control register* contents
+    pub fn modify_outputtieoffcontrol<F>(&mut self, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(registers::OutputTieOffControl) -> registers::OutputTieOffControl,
+    {
+        let value = self.read_outputtieoffcontrol()?;
+        let new_value = f(value);
+        self.write_outputtieoffcontrol(new_value)
+    }
+
+    /// Read a nine-bit register from the chip.
+    ///
+    /// The value comes back in the lowest 9 bits of a `u16`.
+    ///
+    /// ```
+    /// # use nau88c22::{Codec, Register, Error};
+    /// # fn example<I>(codec: &mut Codec<I>) -> Result<(), Error<I::Error>> where I: embedded_hal::i2c::I2c {
+    /// let device_id = codec.read_register(Register::DeviceId)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn read_register(&mut self, register: Register) -> Result<u16, Error<I::Error>> {
+        let mut buffer = [0u8; 2];
+        self.interface
+            .write_read(Self::DEVICE_ADDR, &[register as u8], &mut buffer)?;
+        let mut result = ((buffer[0] as u16) & 1) << 8;
+        result |= buffer[1] as u16;
+        Ok(result)
+    }
+
+    /// Write a nine-bit register to the chip.
+    ///
+    /// The value should be given in the lowest 9 bits of a `u16`.
+    ///
+    /// ```
+    /// # use nau88c22::{Codec, Register, Error};
+    /// # fn example<I>(codec: &mut Codec<I>) -> Result<(), Error<I::Error>> where I: embedded_hal::i2c::I2c {
+    /// codec.write_register(Register::ThreeDControl, 0x5)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn write_register(
+        &mut self,
+        register: Register,
+        value: u16,
+    ) -> Result<(), Error<I::Error>> {
+        let buffer = [register as u8, (value >> 8) as u8, value as u8];
+        self.interface.write(Self::DEVICE_ADDR, &buffer)?;
+        Ok(())
+    }
+
+    /// Modify a nine-bit register on the chip.
+    ///
+    /// Performs a register read, then runs the given closure `f`, then performs
+    /// a register write.
+    ///
+    /// ```
+    /// # use nau88c22::{Codec, Register, Error};
+    /// # fn example<I>(codec: &mut Codec<I>) -> Result<(), Error<I::Error>> where I: embedded_hal::i2c::I2c {
+    /// codec.modify_register(Register::AudioInterface, |w| {
+    ///     w | 0x01
+    /// })?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn modify_register<F>(&mut self, register: Register, f: F) -> Result<(), Error<I::Error>>
+    where
+        F: FnOnce(u16) -> u16,
+    {
+        let value = self.read_register(register)?;
+        let new_value = f(value);
+        self.write_register(register, new_value)
+    }
+}
+
+// End of file

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -12,7 +12,7 @@ use bitfield::bitfield;
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Register {
-    /// Software Reset RESET (SOFTWARE)
+    /// Software Reset
     SoftwareReset = 0x00,
     /// Power Management 1
     PowerManagement1 = 0x01,
@@ -164,44 +164,47 @@ bitfield! {
     ///
     /// * `false` - internal buffer unpowered
     /// * `true` - enabled
-    pub dcbufen, set_dcbufen: 8;
+    pub dcbufen, dcbufen_set: 8;
     /// Power control for AUX1 MIXER supporting AUXOUT1 analog output
     ///
     /// * `false` - unpowered
     /// * `true` - enabled
-    pub aux1mxen, set_aux1mxen: 7;
+    pub aux1mxen, aux1mxen_set: 7;
     /// Power control for AUX2 MIXER supporting AUXOUT2 analog output
     ///
     /// * `false` - unpowered
     /// * `true` - enabled
-    pub aux2mxen, set_aux2mxen: 6;
+    pub aux2mxen, aux2mxen_set: 6;
     /// Power control for internal PLL
     ///
     /// * `false` - unpowered
     /// * `true` - enabled
-    pub pllen, set_pllen: 5;
-    /// Power control for microphone bias buffer amplifier (MICBIAS output, pin#32)
+    pub pllen, pllen_set: 5;
+    /// Power control for microphone bias buffer amplifier (MICBIAS output,
+    /// pin#32)
     ///
     /// * `false` - unpowered and MICBIAS pin in high-Z condition
     /// * `true` - enabled
-    pub micbiasen, set_micbiasen: 4;
+    pub micbiasen, micbiasen_set: 4;
     /// Power control for internal analog bias buffers
     ///
     /// * `false` - unpowered
     /// * `true` - enabled
-    pub abiasen, set_abiasen: 3;
-    /// Power control for internal tie-off buffer used in non-boost mode (-1.0x gain) conditions
+    pub abiasen, abiasen_set: 3;
+    /// Power control for internal tie-off buffer used in non-boost mode (-1.0x
+    /// gain) conditions
     ///
     /// * `false` - internal buffer unpowered
     /// * `true` - enabled
-    pub iobufen, set_iobufen: 2;
-    /// Select impedance of reference string used to establish VREF for internal bias buffers
+    pub iobufen, iobufen_set: 2;
+    /// Select impedance of reference string used to establish VREF for internal
+    /// bias buffers
     ///
     /// * `0` = off (input to internal bias buffer in high-Z floating condition)
-    /// * `1` = 80kΩ nominal impedance at VREF pin
-    /// * `2` = 300kΩ nominal impedance at VREF pin
-    /// * `3` = 3kΩ nominal impedance at VREF pin
-    pub refimp, set_refimp: 1,0;
+    /// * `1` = 80 kΩ nominal impedance at VREF pin
+    /// * `2` = 300 kΩ nominal impedance at VREF pin
+    /// * `3` = 3 kΩ nominal impedance at VREF pin
+    pub refimp, refimp_set: 1,0;
 }
 
 bitfield! {
@@ -217,47 +220,47 @@ bitfield! {
     ///
     /// * `false` = RHP pin in high-Z condition
     /// * `true` = enabled
-    pub rhpen, set_rhpen: 8;
+    pub rhpen, rhpen_set: 8;
     /// Left Headphone driver enabled, LHP analog output pin#30
     ///
     /// * `false` = LHP pin in high-Z condition
     /// * `true` = enabled
-    pub lhpen, set_lhpen: 7;
+    pub lhpen, lhpen_set: 7;
     /// Sleep enable
     ///
     /// * `false` = device in normal operating mode
     /// * `true` = device in low-power sleep condition
-    pub sleep, set_sleep: 6;
+    pub sleep, sleep_set: 6;
     /// Right channel input mixer, RADC Mix/Boost stage power control
     ///
     /// * `false` = RADC Mix/Boost stage OFF
     /// * `true` = RADC Mix/Boost stage ON
-    pub rbsten, set_rbsten: 5;
+    pub rbsten, rbsten_set: 5;
     /// Left channel input mixer, LADC Mix/Boost stage power control
     ///
     /// * `false` = LADC Mix/Boost stage OFF
     /// * `true` = LADC Mix/Boost stage ON
-    pub lbsten, set_lbsten: 4;
+    pub lbsten, lbsten_set: 4;
     /// Right channel input programmable amplifier (PGA) power control
     ///
     /// * `false` = Right PGA input stage OFF
     /// * `true` = enabled
-    pub rpgaen, set_rpgaen: 3;
+    pub rpgaen, rpgaen_set: 3;
     /// Left channel input programmable amplifier power control
     ///
     /// * `false` = Left PGA input stage OFF
     /// * `true` = enabled
-    pub lpgaen, set_lpgaen: 2;
+    pub lpgaen, lpgaen_set: 2;
     /// Right channel analog-to-digital converter power control
     ///
     /// * `false` = Right ADC stage OFF
     /// * `true` = enabled
-    pub radcen, set_radcen: 1;
+    pub radcen, radcen_set: 1;
     /// Left channel analog-to-digital converter power control
     ///
     /// * `false` = Left ADC stage OFF
     /// * `true` = enable
-    pub ladcen, set_ladcen: 0;
+    pub ladcen, ladcen_set: 0;
 }
 
 bitfield! {
@@ -268,46 +271,47 @@ bitfield! {
     /// [`modify_powermanagement3`](crate::Codec::modify_powermanagement3)
     pub struct PowerManagement3(u16);
     impl Debug;
+    u8;
     /// AUXOUT1 analog output power control, pin#21
     ///
     /// * `false` = AUXOUT1 output driver OFF
     /// * `true` = enabled
-    pub auxout1en, set_auxout1en: 8;
+    pub auxout1en, auxout1en_set: 8;
     /// AUXOUT2 analog output power control, pin#22
     ///
     /// * `false` = AUXOUT2 output driver OFF
     /// * `true` = enabled
-    pub auxout2en, set_auxout2en: 7;
+    pub auxout2en, auxout2en_set: 7;
     /// LSPKOUT left speaker driver power control, pin#25
     ///
     /// * `false` = LSPKOUT output driver OFF
     /// * `true` = enabled
-    pub lspken, set_lspken: 6;
+    pub lspken, lspken_set: 6;
     /// RSPKOUT left speaker driver power control, pin#23
     ///
     /// * `false` = RSPKOUT output driver OFF
     /// * `true` = enabled
-    pub rspken, set_rspken: 5;
+    pub rspken, rspken_set: 5;
     /// Right main mixer power control, RMAIN MIXER internal stage
     ///
     /// * `false` = RMAIN MIXER stage OFF
     /// * `true` = enabled
-    pub rmixen, set_rmixen: 3;
+    pub rmixen, rmixen_set: 3;
     /// Left main mixer power control, LMAIN MIXER internal stage
     ///
     /// * `false` = LMAIN MIXER stage OFF
     /// * `true` = enabled
-    pub lmixen, set_lmixen: 2;
+    pub lmixen, lmixen_set: 2;
     /// Right channel digital-to-analog converter, RDAC, power control
     ///
     /// * `false` = RDAC stage OFF
     /// * `true` = enabled
-    pub rdacen, set_rdacen: 1;
+    pub rdacen, rdacen_set: 1;
     /// Left channel digital-to-analog converter, LDAC, power control
     ///
     /// * `false` = LDAC stage OFF
     /// * `true` = enabled
-    pub ldacen, set_ldacen: 0;
+    pub ldacen, ldacen_set: 0;
 }
 
 bitfield! {
@@ -323,7 +327,7 @@ bitfield! {
     ///
     /// * `false` = normal phase
     /// * `true` = input logic sense inverted
-    pub bclkp, set_bclkp: 8;
+    pub bclkp, bclkp_set: 8;
     /// Phase control for I2S audio data bus interface, or PCMA and PCMB
     /// left/right word order control
     ///
@@ -331,36 +335,37 @@ bitfield! {
     /// of BCLK after rising edge of FS
     /// * `true` = inverted phase operation, or MSB is valid on 1st rising edge
     /// of BCLK after rising edge of FS
-    pub lrp, set_lrp: 7;
+    pub lrp, lrp_set: 7;
     /// Word length (24-bits default) of audio data stream
     ///
     /// * `0` = 16-bit word length
     /// * `1` = 20-bit word length
     /// * `2` = 24-bit word length
     /// * `3` = 32-bit word length
-    pub wlen, set_wlen: 6,5;
+    pub wlen, wlen_set: 6,5;
     /// Audio interface data format (default setting is I2S)
     ///
     /// * `0` = right justified
     /// * `1` = left justified
     /// * `2` = standard I2S format
     /// * `3` = PCMA or PCMB audio data format option
-    pub aifmt, set_aifmt: 4,3;
+    pub aifmt, aifmt_set: 4,3;
     /// DAC audio data left-right ordering
     ///
     /// * `false` = left DAC data in left phase of LRP
     /// * `true` = left DAC data in right phase of LRP (left-right reversed)
-    pub dacphs, set_dacphs: 2;
+    pub dacphs, dacphs_set: 2;
     /// ADC audio data left-right ordering
     ///
     /// * `false` = left ADC data is output in left phase of LRP
-    /// * `true` = left ADC data is output in right phase of LRP (left-right reversed)
-    pub adcphs, set_adcphs: 1;
+    /// * `true` = left ADC data is output in right phase of LRP (left-right
+    ///   reversed)
+    pub adcphs, adcphs_set: 1;
     /// Mono operation enable
     ///
     /// * `false` = normal stereo mode of operation
     /// * `true` = mono mode with audio data in left phase of LRP
-    pub mono, set_mono: 0;
+    pub mono, mono_set: 0;
 }
 
 /// Whether 8-bit companding is enabled
@@ -378,10 +383,9 @@ pub enum CompandingMode {
 impl From<u8> for CompandingMode {
     fn from(value: u8) -> Self {
         match value {
-            0 => CompandingMode::Off,
             2 => CompandingMode::ULaw,
             3 => CompandingMode::ALaw,
-            _ => unreachable!(),
+            _ => CompandingMode::Off,
         }
     }
 }
@@ -399,26 +403,21 @@ bitfield! {
     ///
     /// * `false` = normal operation (no companding)
     /// * `true` = 8-bit operation for companding mode
-    pub cmb8, set_cmb8: 5;
+    pub cmb8, cmb8_set: 5;
     /// DAC companding mode control
     ///
     /// * `0` = off (normal linear operation)
     /// * `1` = reserved
     /// * `2` = u-law companding
     /// * `3` = A-law companding
-    pub daccm, set_daccm: 4, 3;
+    pub daccm, daccm_set: 4, 3;
     /// ADC companding mode control
-    ///
-    /// * `0` = off (normal linear operation)
-    /// * `1` = reserved
-    /// * `2` = u-law companding
-    /// * `3` = A-law companding
-    pub into CompandingMode, adccm, set_adccm: 2, 1;
+    pub into CompandingMode, adccm, adccm_set: 2, 1;
     /// DAC audio data input option to route directly to ADC data stream
     ///
     /// * `false` = no passthrough, normal operation
     /// * `true` = ADC output data stream routed to DAC input data path
-    pub addap, set_addap: 0;
+    pub addap, addap_set: 0;
 }
 
 bitfield! {
@@ -434,8 +433,9 @@ bitfield! {
     ///
     /// * `false` = MCLK, pin#11 used as master clock
     /// * `true` = internal PLL oscillator output used as master clock
-    pub clkm, set_clkm: 8;
-    /// Scaling of master clock source for internal 256fs rate (divide by 2 = default)
+    pub clkm, clkm_set: 8;
+    /// Scaling of master clock source for internal 256fs rate (divide by 2 =
+    /// default)
     ///
     /// * `0` = divide by 1
     /// * `1` = divide by 1.5
@@ -445,7 +445,7 @@ bitfield! {
     /// * `5` = divide by 6
     /// * `6` = divide by 8
     /// * `7` = divide by 12
-    pub mclksel, set_mclksel: 7, 5;
+    pub mclksel, mclksel_set: 7, 5;
     /// Scaling of output frequency at BCLK pin#8 when chip is in master mode
     ///
     /// * `0` = divide by 1
@@ -454,12 +454,13 @@ bitfield! {
     /// * `3` = divide by 8
     /// * `4` = divide by 16
     /// * `5` = divide by 32
-    pub bclksel, set_bclksel: 4, 2;
+    pub bclksel, bclksel_set: 4, 2;
     /// Enables chip master mode to drive FS and BCLK outputs
     ///
     /// * `false` = FS and BCLK are inputs
-    /// * `true` = FS and BCLK are driven as outputs by internally generated clocks
-    pub clkioen, set_clkioen: 0;
+    /// * `true` = FS and BCLK are driven as outputs by internally generated
+    ///   clocks
+    pub clkioen, clkioen_set: 0;
 }
 
 bitfield! {
@@ -470,31 +471,32 @@ bitfield! {
     /// [`modify_clockcontrol2`](crate::Codec::modify_clockcontrol2)
     pub struct ClockControl2(u16);
     impl Debug;
+    u8;
     /// 4-wire control interface enable
     ///
     /// * `false` = disabled
     /// * `true` = enabled
-    pub fourwirecie, set_fourwirecie: 8;
-    /// Audio data sample rate indication (48kHz default). Sets up scaling for
+    pub fourwirecie, fourwirecie_set: 8;
+    /// Audio data sample rate indication (48 kHz default). Sets up scaling for
     /// internal filter coefficients, but does not affect in any way the actual
     /// device sample rate. Should be set to value most closely matching the
     /// actual sample rate determined by 256fs internal node.
     ///
-    /// * `0` = 48kHz
-    /// * `1` = 32kHz
-    /// * `2` = 24kHz
-    /// * `3` = 16kHz
-    /// * `4` = 12kHz
-    /// * `5` = 8kHz
+    /// * `0` = 48 kHz
+    /// * `1` = 32 kHz
+    /// * `2` = 24 kHz
+    /// * `3` = 16 kHz
+    /// * `4` = 12 kHz
+    /// * `5` = 8 kHz
     /// * `6` = reserved
     /// * `7` = reserved
-    pub smplr, set_smplr: 3, 1;
+    pub smplr, smplr_set: 3, 1;
     /// Slow timer clock enable. Starts internal timer clock derived by dividing
     /// master clock.
     ///
     /// * `false` = disabled
     /// * `true` = enabled
-    pub sclken, set_sclken: 0;
+    pub sclken, sclken_set: 0;
 }
 
 /// The operating modes CSB/GPIO1 can be in
@@ -503,31 +505,30 @@ bitfield! {
 pub enum Gpio1Selection {
     /// use as input subject to MODE pin#18 input logic level
     Input = 0,
-    /// Temperature OK status output (logic 0 = thermal shutdown)
+    /// Temperature OK status output (low = thermal shutdown)
     TemperatureOk = 2,
-    /// DAC automute condition (logic 1 = one or both DACs automuted)
+    /// DAC automute condition (high = one or both DACs automuted)
     DacIsAutomute = 3,
     /// output divided PLL clock
     PllClock = 4,
-    /// PLL locked condition (logic 1 = PLL locked)
+    /// PLL locked condition (high = PLL locked)
     PllLocked = 5,
-    /// output set to logic 1 condition
+    /// output set to high condition
     LogicHigh = 6,
-    /// output set to logic 0 condition
+    /// output set to low condition
     LogicLow = 7,
 }
 
 impl From<u8> for Gpio1Selection {
     fn from(value: u8) -> Self {
         match value {
-            0 => Gpio1Selection::Input,
             2 => Gpio1Selection::TemperatureOk,
             3 => Gpio1Selection::DacIsAutomute,
             4 => Gpio1Selection::PllClock,
             5 => Gpio1Selection::PllLocked,
             6 => Gpio1Selection::LogicHigh,
             7 => Gpio1Selection::LogicLow,
-            _ => unreachable!(),
+            _ => Gpio1Selection::Input,
         }
     }
 }
@@ -547,23 +548,14 @@ bitfield! {
     /// * `1` = divide by 2
     /// * `2` = divide by 3
     /// * `3` = divide by 4
-    pub gpio1pll, set_gpio1pll: 5, 4;
+    pub gpio1pll, gpio1pll_set: 5, 4;
     /// GPIO1 polarity inversion control
     ///
     /// * `false` = normal logic sense of GPIO signal
     /// * `true` = inverted logic sense of GPIO signal
-    pub gpio1pl, set_gpio1pl: 3;
+    pub gpio1pl, gpio1pl_set: 3;
     /// CSB/GPIO1 function select (input default)
-    ///
-    /// * `0` = use as input subject to MODE pin#18 input logic level
-    /// * `1` = reserved
-    /// * `2` = Temperature OK status output (logic 0 = thermal shutdown)
-    /// * `3` = DAC automute condition (logic 1 = one or both DACs automuted)
-    /// * `4` = output divided PLL clock
-    /// * `5` = PLL locked condition (logic 1 = PLL locked)
-    /// * `6` = output set to logic 1 condition
-    /// * `7` = output set to logic 0 condition
-    pub into Gpio1Selection, gpio1sel, set_gpio1sel: 2, 0;
+    pub into Gpio1Selection, gpio1sel, gpio1sel_set: 2, 0;
 }
 
 bitfield! {
@@ -579,22 +571,22 @@ bitfield! {
     /// sensed through GPIO pin associated to jack detection function
     ///
     /// * `0` = disabled
-    /// * `1` = enable bias amplifiers on jack at logic 0 level
-    /// * `2` = enable bias amplifiers on jack at logic 1 level
+    /// * `1` = enable bias amplifiers on jack at `false` level
+    /// * `2` = enable bias amplifiers on jack at `true` level
     /// * `3` = reserved
-    pub jckmiden, set_jckmiden: 8, 7;
+    pub jckmiden, jckmiden_set: 8, 7;
     /// Jack detection feature enable
     ///
     /// * `false` = disabled
     /// * `true` = enable jack detection associated functionality
-    pub jacden, set_jacden: 6;
+    pub jacden, jacden_set: 6;
     /// Select jack detect pin (GPIO1 default)
     ///
     /// * `0` = GPIO1 is used for jack detection feature
     /// * `1` = GPIO2 is used for jack detection feature
     /// * `2` = GPIO3 is used for jack detection feature
     /// * `3` = reserved
-    pub jckdio, set_jckdio: 5, 4;
+    pub jckdio, jckdio_set: 5, 4;
 }
 
 bitfield! {
@@ -610,27 +602,27 @@ bitfield! {
     ///
     /// * `false` = disabled
     /// * `true` = enabled
-    pub softmt, set_softmt: 6;
+    pub softmt, softmt_set: 6;
     /// DAC oversampling rate selection (64X default)
     ///
     /// * `false` = 64x oversampling
     /// * `true` = 128x oversampling
-    pub dacos, set_dacos: 3;
+    pub dacos, dacos_set: 3;
     /// DAC automute function enable
     ///
     /// * `false` = disabled
     /// * `true` = enabled
-    pub automt, set_automt: 2;
+    pub automt, automt_set: 2;
     /// DAC right channel output polarity control
     ///
     /// * `false` = normal polarity
     /// * `true` = inverted polarity
-    pub rdacpl, set_rdacpl: 1;
+    pub rdacpl, rdacpl_set: 1;
     /// DAC left channel output polarity control
     ///
     /// * `false` = normal polarity
     /// * `true` = inverted polarity
-    pub ldacpl, set_ldacpl: 0;
+    pub ldacpl, ldacpl_set: 0;
 }
 
 bitfield! {
@@ -645,19 +637,21 @@ bitfield! {
     /// DAC volume update bit feature. Write-only bit for synchronized L/R DAC
     /// changes
     ///
-    /// * `false` = on R11 write, new R11 value stored in temporary register
-    /// * `true` = on R11 write, new R11 and pending R12 values become active
-    pub _, set_ldacvu: 8;
-    /// DAC left digital volume control (0dB default attenuation value).
-    /// Expressed as an attenuation value in 0.5dB steps as follows:
+    /// * `false` = on [`LeftDACVolume`] write, new [`LeftDACVolume`] value
+    ///   stored in temporary register
+    /// * `true` = on [`LeftDACVolume`] write, new [`LeftDACVolume`] and pending
+    ///   [`RightDACVolume`] values become active
+    pub _, ldacvu_set: 8;
+    /// DAC left digital volume control (0 dB default attenuation value).
+    /// Expressed as an attenuation value in 0.5 dB steps as follows:
     ///
     /// * `0` = digital mute condition
-    /// * `1` = -127.0dB (highly attenuated)
-    /// * `2` = -126.5dB attenuation
+    /// * `1` = -127.0 dB (highly attenuated)
+    /// * `2` = -126.5 dB attenuation
     /// * all intermediate 0.5 step values through to maximum
-    /// * `254` = -0.5dB attenuation
-    /// * `255` = 0.0dB attenuation (no attenuation
-    pub ldacgain, set_ldacgain: 7, 0;
+    /// * `254` = -0.5 dB attenuation
+    /// * `255` = 0.0 dB attenuation (no attenuation
+    pub ldacgain, ldacgain_set: 7, 0;
 }
 
 bitfield! {
@@ -668,22 +662,25 @@ bitfield! {
     /// [`modify_rightdacvolume`](crate::Codec::modify_rightdacvolume)
     pub struct RightDACVolume(u16);
     impl Debug;
+    u8;
     /// DAC volume update bit feature. Write-only bit for synchronized L/R DAC
     /// changes
     ///
-    /// * `false` = on R12 write, new R12 value stored in temporary register
-    /// * `true` = on R12 write, new R12 and pending R12 values become active
-    pub _, set_rdacvu: 8;
-    /// DAC right digital volume control (0dB default attenuation value).
-    /// Expressed as an attenuation value in 0.5dB steps as follows:
+    /// * `false` = on [`RightDACVolume`] write, new [`RightDACVolume`] value
+    ///   stored in temporary register
+    /// * `true` = on [`RightDACVolume`] write, new [`RightDACVolume`] and
+    ///   pending [`LeftDACVolume`] values become active
+    pub _, rdacvu_set: 8;
+    /// DAC right digital volume control (0 dB default attenuation value).
+    /// Expressed as an attenuation value in 0.5 dB steps as follows:
     ///
     /// * `0` = digital mute condition
-    /// * `1` = -127.0dB (highly attenuated)
-    /// * `2` = -126.5dB attenuation
+    /// * `1` = -127.0 dB (highly attenuated)
+    /// * `2` = -126.5 dB attenuation
     /// * all intermediate 0.5 step values through to maximum
-    /// * `254` = -0.5dB attenuation
-    /// * `255` = 0.0dB attenuation (no attenuation
-    pub rdacgain, set_rdacgain: 7, 0;
+    /// * `254` = -0.5 dB attenuation
+    /// * `255` = 0.0 dB attenuation (no attenuation
+    pub rdacgain, rdacgain_set: 7, 0;
 }
 
 bitfield! {
@@ -694,7 +691,25 @@ bitfield! {
     /// [`modify_jackdetect2`](crate::Codec::modify_jackdetect2)
     pub struct JackDetect2(u16);
     impl Debug;
-
+    u8;
+    /// Outputs drivers that are automatically enabled whenever the designated
+    /// jack detection input is in the `true` condition, and the jack
+    /// detection feature is enabled
+    ///
+    /// * Bit 0 = `1`: enable Left and Right Headphone output drivers
+    /// * Bit 1 = `1`: enable Left and Right Speaker output drivers
+    /// * Bit 2 = `1`: enable AUXOUT2 output driver
+    /// * Bit 3 = `1`: enable AUXOUT1 output driver
+    pub jckdoen1_lrhp, jckdoen1_set: 7, 4;
+    /// Outputs drivers that are automatically enabled whenever the designated
+    /// jack detection input is in the low condition, and the jack detection
+    /// feature is enabled
+    ///
+    /// * Bit 0 = `1`: enable Left and Right Headphone output drivers
+    /// * Bit 1 = `1`: enable Left and Right Speaker output drivers
+    /// * Bit 2 = `1`: enable AUXOUT2 output driver
+    /// * Bit 3 = `1`: enable AUXOUT1 output driver
+    pub jckdoen0_lrhp, jckdoen0_set: 3, 0;
 }
 
 bitfield! {
@@ -705,7 +720,38 @@ bitfield! {
     /// [`modify_adccontrol`](crate::Codec::modify_adccontrol)
     pub struct ADCControl(u16);
     impl Debug;
-
+    u8;
+    /// High pass filter enable control for filter of ADC output data stream
+    ///
+    /// * `false` = high pass filter disabled
+    /// * `true` = high pass filter enabled
+    pub hpfen, hpfen_set: 8;
+    /// High pass filter mode selection
+    ///
+    /// * `false` = normal audio mode, 1st order 3.7 Hz high pass filter for DC
+    ///   blocking
+    /// * `true` = application specific mode, variable 2nd order high pass
+    ///   filter
+    pub hpfam, hpfam_set: 7;
+    /// Application specific mode cutoff frequency selection
+    ///
+    /// See datasheet for details.
+    pub hpf, hpf_set: 6, 4;
+    /// ADC oversampling rate selection (64X default)
+    ///
+    /// * `false` = 64x oversampling rate for reduced power
+    /// * `true` = 128x oversampling for better SNR
+    pub adcos, adcos_set: 3;
+    /// ADC right channel polarity control
+    ///
+    /// * `false` = normal polarity
+    /// * `true` = sign of RADC output is inverted from normal polarity
+    pub radcpl, radcpl_set: 1;
+    /// ADC left channel polarity control
+    ///
+    /// * `false` = normal polarity
+    /// * `true` = sign of LADC output is inverted from normal polarity
+    pub ladcpl, ladcpl_set: 0;
 }
 
 bitfield! {
@@ -716,7 +762,25 @@ bitfield! {
     /// [`modify_leftadcvolume`](crate::Codec::modify_leftadcvolume)
     pub struct LeftADCVolume(u16);
     impl Debug;
-
+    u8;
+    /// ADC volume update bit feature. Write-only bit for synchronized L/R ADC
+    /// changes.
+    ///
+    /// * If `false` on [`LeftADCVolume`] write, new [`LeftADCVolume`] value
+    ///   stored in temporary register
+    /// * If `true` on [`LeftADCVolume`] write, new [`LeftADCVolume`] and
+    ///   pending [`RightADCVolume`] values become active
+    pub _, ladcvu_set: 8;
+    /// ADC left digital volume control (0 dB default attenuation value).
+    /// Expressed as an attenuation value in 0.5 dB steps as follows:
+    ///
+    /// * `0` = digital mute condition
+    /// * `1` = -127.0 dB (highly attenuated)
+    /// * `2` = -126.5 dB attenuation
+    /// * *all intermediate 0.5 step values through maximum volume*
+    /// * `254` = -0.5 dB attenuation
+    /// * `255` = 0.0 dB attenuation (no attenuation)
+    pub ladcgain, ladcgain_set: 7, 0;
 }
 
 bitfield! {
@@ -727,7 +791,25 @@ bitfield! {
     /// [`modify_rightadcvolume`](crate::Codec::modify_rightadcvolume)
     pub struct RightADCVolume(u16);
     impl Debug;
-
+    u8;
+    /// ADC volume update bit feature. Write-only bit for synchronized L/R ADC
+    /// changes.
+    ///
+    /// * If `false` on [`RightADCVolume`] write, new [`RightADCVolume`] value
+    /// * stored in temporary register
+    /// * If `true` on [`RightADCVolume`] write, new [`RightADCVolume`] and
+    /// * pending [`LeftADCVolume`] values become active
+    pub _, radcvu_set: 8;
+    /// ADC right digital volume control (0 dB default attenuation value).
+    /// Expressed as an attenuation value in 0.5 dB steps as follows:
+    ///
+    /// * `0` = digital mute condition
+    /// * `1` = -127.0 dB (highly attenuated)
+    /// * `2` = -126.5 dB attenuation
+    /// * *all intermediate 0.5 step values through maximum volume*
+    /// * `254` = -0.5 dB attenuation
+    /// * `255` = 0.0 dB attenuation (no attenuation)
+    pub radcgain, radcgain_set: 7, 0;
 }
 
 bitfield! {
@@ -738,7 +820,28 @@ bitfield! {
     /// [`modify_eq1highcutoff`](crate::Codec::modify_eq1highcutoff)
     pub struct EQ1HighCutoff(u16);
     impl Debug;
-
+    u8;
+    /// Equalizer and 3D audio processing block assignment.
+    ///
+    /// * `false` = block operates on digital stream from ADC
+    /// * `true` = block operates on digital stream to DAC (default on reset)
+    pub eqm, eqm_set: 8;
+    /// Equalizer band 1 high pass -3 dB cut-off frequency selection
+    ///
+    /// * `0` = 80 Hz
+    /// * `1` = 105 Hz (default)
+    /// * `2` = 135 Hz
+    /// * `3` = 175 Hz
+    pub eq1cf, eq1cf_set: 6, 5;
+    /// EQ Band 1 digital gain control. Expressed as a gain or attenuation in
+    /// 1 dB steps. `12` = 0.0 dB default unity gain value.
+    ///
+    /// * `0` = +12 dB
+    /// * `1` = +11 dB
+    /// * *all intermediate 1.0 dB step values through minimum gain*
+    /// * `24` = -12 dB
+    /// * `25` and larger values are reserved
+    pub eq1gc, eq1gc_set: 4, 0;
 }
 
 bitfield! {
@@ -749,7 +852,30 @@ bitfield! {
     /// [`modify_eq2peak1`](crate::Codec::modify_eq2peak1)
     pub struct EQ2Peak1(u16);
     impl Debug;
-
+    u8;
+    /// Equalizer Band 2 bandwidth selection
+    ///
+    /// * `false` = narrow band characteristic (default)
+    /// * `true` = wide band characteristic
+    pub eq2bw, eq2bw_set: 8;
+    /// Equalizer Band 2 center frequency selection
+    ///
+    /// * `0` = 230 Hz
+    /// * `1` = 300 Hz (default)
+    /// * `2` = 385 Hz
+    /// * `3` = 500 Hz
+    pub eq2cf, eq2cf_set: 6, 5;
+    /// EQ Band 2 digital gain control.
+    ///
+    /// Expressed as a gain or attenuation in 1 dB steps. `12` = 0.0 dB default
+    /// unity gain value.
+    ///
+    /// * `0` = +12 dB
+    /// * `1` = +11 dB
+    /// * *all intermediate 1.0 dB step values through minimum gain*
+    /// * `24` = -12 dB
+    /// * `25` and larger values are reserved
+    pub eq2gc, eq2gc_set: 4, 0;
 }
 
 bitfield! {
@@ -760,7 +886,30 @@ bitfield! {
     /// [`modify_eq3peak2`](crate::Codec::modify_eq3peak2)
     pub struct EQ3Peak2(u16);
     impl Debug;
-
+    u8;
+    /// Equalizer Band 3 bandwidth selection
+    ///
+    /// * `false` = narrow band characteristic (default)
+    /// * `true` = wide band characteristic
+    pub eq3bw, eq3bw_set: 8;
+    /// Equalizer Band 3 center frequency selection
+    ///
+    /// * `0` = 650 Hz
+    /// * `1` = 850 Hz (default)
+    /// * `2` = 1.1 kHz
+    /// * `3` = 1.4 kHz
+    pub eq3cf, eq3cf_set: 6, 5;
+    /// EQ Band 3 digital gain control.
+    ///
+    /// Expressed as a gain or attenuation in 1 dB steps. `12` = 0.0 dB default
+    /// unity gain value.
+    ///
+    /// * `0` = +12 dB
+    /// * `1` = +11 dB
+    /// * *all intermediate 1.0 dB step values through minimum gain*
+    /// * `24` = -12 dB
+    /// * `25` and larger values are reserved
+    pub eq3gc, eq3gc_set: 4, 0;
 }
 
 bitfield! {
@@ -771,7 +920,30 @@ bitfield! {
     /// [`modify_eq4peak3`](crate::Codec::modify_eq4peak3)
     pub struct EQ4Peak3(u16);
     impl Debug;
-
+    u8;
+    /// Equalizer Band 4 bandwidth selection
+    ///
+    /// * `false` = narrow band characteristic (default)
+    /// * `true` = wide band characteristic
+    pub eq4bw, eq4bw_set: 8;
+    /// Equalizer Band 4 center frequency selection
+    ///
+    /// * `0` = 1.8 kHz
+    /// * `1` = 2.4 kHz (default)
+    /// * `2` = 3.2 kHz
+    /// * `3` = 4.1 kHz
+    pub eq4cf, eq4cf_set: 6, 5;
+    /// EQ Band 4 digital gain control.
+    ///
+    /// Expressed as a gain or attenuation in 1 dB steps. `12` = 0.0 dB default
+    /// unity gain value.
+    ///
+    /// * `0` = +12 dB
+    /// * `1` = +11 dB
+    /// * *all intermediate 1.0 dB step values through minimum gain*
+    /// * `24` = -12 dB
+    /// * `25` and larger values are reserved
+    pub eq4gc, eq4gc_set: 4, 0;
 }
 
 bitfield! {
@@ -782,7 +954,25 @@ bitfield! {
     /// [`modify_eq5lowcutoff`](crate::Codec::modify_eq5lowcutoff)
     pub struct EQ5LowCutoff(u16);
     impl Debug;
-
+    u8;
+    /// Equalizer Band 5 center frequency selection
+    ///
+    /// * `0` = 5.3 kHz
+    /// * `1` = 6.9 kHz (default)
+    /// * `2` = 9.0 kHz
+    /// * `3` = 11.7 kHz
+    pub eq5cf, eq5cf_set: 6, 5;
+    /// EQ Band 5 digital gain control.
+    ///
+    /// Expressed as a gain or attenuation in 1 dB steps. `12` = 0.0 dB default
+    /// unity gain value.
+    ///
+    /// * `0` = +12 dB
+    /// * `1` = +11 dB
+    /// * *all intermediate 1.0 dB step values through minimum gain*
+    /// * `24` = -12 dB
+    /// * `25` and larger values are reserved
+    pub eq5gc, eq5gc_set: 4, 0;
 }
 
 bitfield! {
@@ -793,7 +983,46 @@ bitfield! {
     /// [`modify_daclimiter1`](crate::Codec::modify_daclimiter1)
     pub struct DACLimiter1(u16);
     impl Debug;
-
+    u8;
+    /// DAC digital limiter control bit
+    ///
+    /// * `false` = disabled
+    /// * `true` = enabled
+    pub daclimen, daclimen_set: 8;
+    /// DAC limiter decay time. Proportional to actual DAC sample rate. Duration
+    /// doubles with each binary bit value. Values given here are for 44.1 kHz
+    /// sample rate.
+    ///
+    /// * `0` = 0.544 ms
+    /// * `1` = 1.09 ms
+    /// * `2` = 2.18 ms
+    /// * `3` = 4.36 ms (default)
+    /// * `4` = 8.72 ms
+    /// * `5` = 17.4 ms
+    /// * `6` = 34.8 ms
+    /// * `7` = 69.6 ms
+    /// * `8` = 139 ms
+    /// * `9` = 278 ms
+    /// * `10` = 566 ms
+    /// * `11` through `15` = 1130 ms
+    pub daclimdcy, daclimdcy_set: 7, 4;
+    /// DAC limiter attack time. Proportional to actual DAC sample rate.
+    /// Duration doubles with each binary bit value. Values given here are for
+    /// 44.1 kHz sample rate.
+    ///
+    /// * `0` = 68.0 µs
+    /// * `1` = 136 µs
+    /// * `2` = 272 µs (default)
+    /// * `3` = 544 µs
+    /// * `4` = 1.09 ms
+    /// * `5` = 2.18 ms
+    /// * `6` = 4.36 ms
+    /// * `7` = 8.72 ms
+    /// * `8` = 17.4 ms
+    /// * `9` = 34.8 ms
+    /// * `10` = 69.6 ms
+    /// * `11` through `15` = 139 ms
+    pub daclimatk, daclimatk_set: 4, 0;
 }
 
 bitfield! {
@@ -804,7 +1033,28 @@ bitfield! {
     /// [`modify_daclimiter2`](crate::Codec::modify_daclimiter2)
     pub struct DACLimiter2(u16);
     impl Debug;
-
+    u8;
+    /// DAC limiter threshold in relation to full scale output level (0.0 dB =
+    /// full scale)
+    ///
+    /// * `0` = -1.0 dB
+    /// * `1` = -2.0 dB
+    /// * `2` = -3.0 dB
+    /// * `3` = -4.0 dB
+    /// * `4` = -5.0 dB
+    /// * `5` through `7` = -6.0 dB
+    pub daclimthl, daclimthl_set: 6, 4;
+    /// DAC limiter maximum automatic gain boost in limiter mode.
+    ///
+    /// If R24 (`DACLimiter1`) limiter mode is disabled, specified gain value
+    /// will be applied in addition to other gain values in the signal path.
+    ///
+    /// * `0` = 0.0 dB (default)
+    /// * `1` = +1.0 dB
+    /// * *Gain value increases in 1.0 dB steps for each binary value*
+    /// * `12` = +12 dB (maximum allowed boost value)
+    /// * `13` through `15` = reserved
+    pub daclimbst, daclimbst_set: 3, 0;
 }
 
 bitfield! {
@@ -815,7 +1065,26 @@ bitfield! {
     /// [`modify_notchfilter1`](crate::Codec::modify_notchfilter1)
     pub struct NotchFilter1(u16);
     impl Debug;
-
+    u8;
+    /// Update bit feature for simultaneous change of all notch filter
+    /// parameters. Write-only bit.
+    ///
+    /// * Setting `true` on [`NotchFilter1`] register write operation causes new
+    /// [`NotchFilter1`] value and any pending value in [`NotchFilter2`],
+    /// [`NotchFilter3`], or [`NotchFilter4`] to go into effect.
+    /// * Setting `false` on [`NotchFilter1`] register write causes new value to
+    /// be pending an update bit event on [`NotchFilter1`], [`NotchFilter2`],
+    /// [`NotchFilter3`], or [`NotchFilter4`].
+    pub _, nfcu1_set: 8;
+    /// Notch filter control bit
+    ///
+    /// * `false` = disabled
+    /// * `true` = enabled
+    pub nfcen, nfcen_set: 7;
+    /// Notch filter A0 coefficient most significant bits.
+    ///
+    /// See datasheet for details.
+    pub nfca0high, nfca0high_set: 6, 0;
 }
 
 bitfield! {
@@ -826,7 +1095,21 @@ bitfield! {
     /// [`modify_notchfilter2`](crate::Codec::modify_notchfilter2)
     pub struct NotchFilter2(u16);
     impl Debug;
-
+    u8;
+    /// Update bit feature for simultaneous change of all notch filter
+    /// parameters. Write-only bit.
+    ///
+    /// * Setting `true` on [`NotchFilter2`] register write operation causes new
+    /// [`NotchFilter2`] value and any pending value in [`NotchFilter1`],
+    /// [`NotchFilter3`], or [`NotchFilter4`] to go into effect.
+    /// * Setting `false` on [`NotchFilter2`] register write causes new value to
+    /// be pending an update bit event on [`NotchFilter1`], [`NotchFilter2`],
+    /// [`NotchFilter3`], or [`NotchFilter4`].
+    pub _, nfcu2_set: 8;
+    /// Notch filter A0 coefficient least significant bits
+    ///
+    /// See datasheet for details.
+    pub nfcaolow, nfcaolow_set: 6, 0;
 }
 
 bitfield! {
@@ -837,7 +1120,21 @@ bitfield! {
     /// [`modify_notchfilter3`](crate::Codec::modify_notchfilter3)
     pub struct NotchFilter3(u16);
     impl Debug;
-
+    u8;
+    /// Update bit feature for simultaneous change of all notch filter
+    /// parameters. Write-only bit.
+    ///
+    /// * Setting `true` on [`NotchFilter3`] register write operation causes new
+    /// [`NotchFilter3`] value and any pending value in [`NotchFilter1`],
+    /// [`NotchFilter2`], or [`NotchFilter4`] to go into effect.
+    /// * Setting `false` on [`NotchFilter3`] register write causes new value to
+    /// be pending an update bit event on [`NotchFilter1`], [`NotchFilter2`],
+    /// [`NotchFilter3`], or [`NotchFilter4`].
+    pub _, nfcu3_set: 8;
+    /// Notch filter A1 coefficient most significant bits
+    ///
+    /// See datasheet for details.
+    pub nfca1high, nfca1high_set: 6, 0;
 }
 
 bitfield! {
@@ -848,7 +1145,21 @@ bitfield! {
     /// [`modify_notchfilter4`](crate::Codec::modify_notchfilter4)
     pub struct NotchFilter4(u16);
     impl Debug;
-
+    u8;
+    /// Update bit feature for simultaneous change of all notch filter
+    /// parameters. Write-only bit.
+    ///
+    /// * Setting `true` on [`NotchFilter4`] register write operation causes new
+    /// [`NotchFilter4`] value and any pending value in [`NotchFilter1`],
+    /// [`NotchFilter2`], or [`NotchFilter3`] to go into effect.
+    /// * Setting `false` on [`NotchFilter4`] register write causes new value to
+    /// be pending an update bit event on [`NotchFilter1`], [`NotchFilter2`],
+    /// [`NotchFilter3`], or [`NotchFilter4`].
+    pub _, nfcu4_set: 8;
+    /// Notch filter A1 coefficient least significant bits
+    ///
+    /// See datasheet for details.
+    pub nfca1low, nfca1low_set: 6, 0;
 }
 
 bitfield! {
@@ -859,7 +1170,37 @@ bitfield! {
     /// [`modify_alccontrol1`](crate::Codec::modify_alccontrol1)
     pub struct ALCControl1(u16);
     impl Debug;
-
+    u8;
+    /// Automatic Level Control function control bits
+    ///
+    /// * `0` = right and left ALCs disabled
+    /// * `1` = only right channel ALC enabled
+    /// * `2` = only left channel ALC enabled
+    /// * `3` = both right and left channel ALCs enabled
+    pub alcen, alcen_set: 8, 7;
+    /// Set maximum gain limit for PGA volume setting changes under ALC control
+    ///
+    /// * `7` = +35.25 dB (default)
+    /// * `6` = +29.25 dB
+    /// * `5` = +23.25 dB
+    /// * `4` = +17.25 dB
+    /// * `3` = +11.25 dB
+    /// * `2` = +5.25 dB
+    /// * `1` = -0.75 dB
+    /// * `0` = -6.75 dB
+    pub alcmxgain, alcmxgain_set: 5, 3;
+    /// Set minimum gain value limit for PGA volume setting changes under ALC
+    /// control
+    ///
+    /// * `0` = -12 dB (default)
+    /// * `1` = -6.0 dB
+    /// * `2` = 0.0 dB
+    /// * `3` = +6.0 dB
+    /// * `4` = +12 dB
+    /// * `5` = +18 dB
+    /// * `6` = +24 dB
+    /// * `7` = +30 dB
+    pub alcmngain, alcmngain_set: 2, 0;
 }
 
 bitfield! {
@@ -870,7 +1211,27 @@ bitfield! {
     /// [`modify_alccontrol2`](crate::Codec::modify_alccontrol2)
     pub struct ALCControl2(u16);
     impl Debug;
-
+    u8;
+    /// Hold time before ALC automated gain increase
+    ///
+    /// * `0` = 0.00 ms (default)
+    /// * `1` = 2.00 ms
+    /// * `2` = 4.00 ms
+    /// * *time value doubles with each bit value increment*
+    /// * `9` = 512 ms
+    /// * `10` through `15` = 1000 ms
+    pub alcht, alcht_set: 7, 4;
+    /// ALC target level at ADC output
+    ///
+    /// * `15` = -1.5 dB below full scale (FS)
+    /// * `14` = -1.5 dB FS (same value as `15`)
+    /// * `13` = -3.0 dB FS
+    /// * `12` = -4.5 dB FS
+    /// * `11` = -6.0 dB FS (default)
+    /// * *target level varies 1.5 dB per binary step throughout control range*
+    /// * `1` = -21.0 dB FS
+    /// * `0` = -22.5 dB FS (lowest possible target signal level)
+    pub alcsl, alcsl_set: 3, 0;
 }
 
 bitfield! {
@@ -881,7 +1242,48 @@ bitfield! {
     /// [`modify_alccontrol3`](crate::Codec::modify_alccontrol3)
     pub struct ALCControl3(u16);
     impl Debug;
-
+    u8;
+    /// ALC mode control setting
+    ///
+    /// * `false` = normal ALC operation
+    /// * `true` = Limiter Mode operation
+    pub alcm, alcm_set: 8;
+    /// ALC decay time duration per step of gain change for gain increase of
+    /// 0.75 dB of PGA gain. Total response time can be estimated by the total
+    /// number of steps necessary to compensate for a given magnitude change in
+    /// the signal. For example, a 6 dB decrease in the signal would require
+    /// eight ALC steps to compensate.
+    ///
+    /// Step size for each mode is given by:
+    ///
+    /// | Normal Mode                | Limiter Mode               |
+    /// | -------------------------- | -------------------------- |
+    /// | `0` = 500 µs               | `0` = 125 µs               |
+    /// | `1` = 1.0 ms               | `1` = 250 µs               |
+    /// | `2` = 2.0 ms (default)     | `2` = 500 µs (default)     |
+    /// | ...                        | ...                        |
+    /// | `8` = 128 ms               | `8` = 32 ms                |
+    /// | `9` = 256 ms               | `9` = 64 ms                |
+    /// | `10` through `15` = 512 ms | `10` through `15` = 128 ms |
+    pub alcdcy, alcdcy_set: 7, 4;
+    /// ALC attack time duration per step of gain change for gain decrease of
+    /// 0.75 dB of PGA gain. Total response time can be estimated by the total
+    /// number of steps necessary to compensate for a given magnitude change in
+    /// the signal. For example, a 6 dB increase in the signal would require
+    /// eight ALC steps to compensate.
+    ///
+    /// Step size for each mode is given by:
+    ///
+    /// | Normal Mode                | Limiter Mode                |
+    /// | -------------------------- | --------------------------- |
+    /// | `0` = 125 µs               | `0` = 31 µs                 |
+    /// | `1` = 250 µs               | `1` = 62 µs                 |
+    /// | `2` = 500 µs (default)     | `2` = 124 µs (default)      |
+    /// | ...                        | ...                         |
+    /// | `8` = 26.5 ms              | `8` = 7.95 ms               |
+    /// | `9` = 53.0 ms              | `9` = 15.9 ms               |
+    /// | `10` through `15` = 128 ms | `10` through `15` = 31.7 ms |
+    pub alcatk, alcatk_set: 3, 0;
 }
 
 bitfield! {
@@ -892,6 +1294,24 @@ bitfield! {
     /// [`modify_noisegate`](crate::Codec::modify_noisegate)
     pub struct NoiseGate(u16);
     impl Debug;
+    u8;
+    /// ALC noise gate function control bit
+    ///
+    /// * `false` = disabled
+    /// * `true` = enabled
+    pub alcnen, alcnen_set: 3;
+    /// ALC noise gate threshold level
+    ///
+    /// * `0` = -39 dB (default)
+    /// * `1` = -45 dB
+    /// * `2` = -51 dB
+    /// * `3` = -57 dB
+    /// * `4` = -63 dB
+    /// * `5` = -69 dB
+    /// * `6` = -75 dB
+    /// * `7` = -81 dB
+    pub alcnth, alcnth_set: 2, 0;
+
 
 }
 
@@ -903,7 +1323,18 @@ bitfield! {
     /// [`modify_plln`](crate::Codec::modify_plln)
     pub struct PllN(u16);
     impl Debug;
-
+    u8;
+    /// Control bit for divide by 2 pre-scale of MCLK path to PLL clock input
+    ///
+    /// * `false` = MCLK divide by 1 (default)
+    /// * `true` = MCLK divide by 2
+    pub pllmclk, pllmclk_set: 4;
+    /// Integer portion of PLL input/output frequency ratio divider. Decimal
+    /// value should be constrained to 6, 7, 8, 9, 10, 11, or 12. Default
+    /// decimal value is 8.
+    ///
+    /// See datasheet for details.
+    pub plln, plln_set: 3, 0;
 }
 
 bitfield! {
@@ -914,7 +1345,12 @@ bitfield! {
     /// [`modify_pllk1`](crate::Codec::modify_pllk1)
     pub struct PllK1(u16);
     impl Debug;
-
+    u8;
+    /// High order bits of fractional portion of PLL input/output frequency
+    /// ratio divider.
+    ///
+    /// See datasheet for details.
+    pub pllkhigh, pllkhigh_set: 5, 0;
 }
 
 bitfield! {
@@ -925,7 +1361,12 @@ bitfield! {
     /// [`modify_pllk2`](crate::Codec::modify_pllk2)
     pub struct PllK2(u16);
     impl Debug;
-
+    u8;
+    /// Middle order bits of fractional portion of PLL input/output frequency
+    /// ratio divider.
+    ///
+    /// See datasheet for details.
+    pub pllkmedium, pllkmedium_set: 8, 0;
 }
 
 bitfield! {
@@ -936,7 +1377,12 @@ bitfield! {
     /// [`modify_pllk3`](crate::Codec::modify_pllk3)
     pub struct PllK3(u16);
     impl Debug;
-
+    u8;
+    /// Low order bits of fractional portion of PLL input/output frequency ratio
+    /// divider.
+    ///
+    /// See datasheet for details.
+    pub pllklow, pllklow_set: 8, 0;
 }
 
 bitfield! {
@@ -947,7 +1393,16 @@ bitfield! {
     /// [`modify_threedcontrol`](crate::Codec::modify_threedcontrol)
     pub struct ThreeDControl(u16);
     impl Debug;
-
+    u8;
+    /// 3D Stereo Enhancement effect depth control
+    ///
+    /// * `0` = 0.0% effect (disabled, default)
+    /// * `1` = 6.67% effect
+    /// * `2` = 13.3% effect
+    /// * *3 depth varies by 6.67% per binary bit value*
+    /// * `4` = 93.3% effect
+    /// * `5` = 100% effect (maximum effect)
+    pub threeddepth, threeddepth_set: 3, 0;
 }
 
 bitfield! {
@@ -958,7 +1413,36 @@ bitfield! {
     /// [`modify_rightspeakersubmix`](crate::Codec::modify_rightspeakersubmix)
     pub struct RightSpeakerSubmix(u16);
     impl Debug;
-
+    u8;
+    /// Mutes the RMIX speaker signal gain stage output in the right speaker
+    /// submixer
+    ///
+    /// * `false` = gain stage output enabled
+    /// * `true` = gain stage output muted
+    pub rmixmut, rmixmut_set: 5;
+    /// Right speaker submixer bypass control
+    ///
+    /// * `false` = right speaker amplifier directly connected to RMIX speaker
+    ///   signal gain stage
+    /// * `true` = right speaker amplifier connected to submixer output (inverts
+    ///   RMIX for BTL)
+    pub rsubbyp, rsubbyp_set: 4;
+    /// RAUXIN to Right Speaker Submixer input gain control
+    ///
+    /// * `0` = -15 dB (default)
+    /// * `1` = -12 dB
+    /// * `2` = -9.0 dB
+    /// * `3` = -6.0 dB
+    /// * `4` = -3.0 dB
+    /// * `5` = 0.0 dB
+    /// * `6` = +3.0 dB
+    /// * `7` = +6.0 dB
+    pub rauxrsubg, rauxrsubg_set: 3, 1;
+    /// RAUXIN to Right Speaker Submixer mute control
+    ///
+    /// * `false` = RAUXIN path to submixer is muted
+    /// * `true` = RAUXIN path to submixer is enabled
+    pub rauxsmut, rauxsmut_set: 0;
 }
 
 bitfield! {
@@ -969,7 +1453,50 @@ bitfield! {
     /// [`modify_inputcontrol`](crate::Codec::modify_inputcontrol)
     pub struct InputControl(u16);
     impl Debug;
-
+    u8;
+    /// Microphone bias voltage selection control. Values change slightly with
+    /// MICBIAS mode selection control. Open circuit voltage on MICBIAS pin#32
+    /// is shown as follows as a fraction of the VDDA pin#31 supply voltage.
+    ///
+    /// | Normal Mode | Low Noise Mode |
+    /// | ----------- | -------------- |
+    /// | `0` = 0.9x  | `0` = 0.85x    |
+    /// | `1` = 0.65x | `1` = 0.60x    |
+    /// | `2` = 0.75x | `2` = 0.70x    |
+    /// | `3` = 0.50x | `3` = 0.50x    |
+    pub micbiasv, micbiasv_set: 8, 7;
+    /// RLIN right line input path control to right PGA positive input
+    ///
+    /// * `false` = RLIN not connected to PGA positive input (default)
+    /// * `true` = RLIN connected to PGA positive input
+    pub rlinrpga, rlinrpga_set: 6;
+    /// RMICN right microphone negative input to right PGA negative input path
+    /// control
+    ///
+    /// * `false` = RMICN not connected to PGA negative input (default)
+    /// * `true` = RMICN connected to PGA negative input
+    pub rmicnrpga, rmicnrpga_set: 5;
+    /// RMICP right microphone positive input to right PGA positive input enable
+    ///
+    /// * `false` = RMICP not connected to PGA positive input (default)
+    /// * `true` = RMICP connected to PGA positive input
+    pub rmicprpga, rmicprpga_set: 4;
+    /// LLIN right line input path control to left PGA positive input
+    ///
+    /// * `false` = LLIN not connected to PGA positive input (default)
+    /// * `true` = LLIN connected to PGA positive input
+    pub llinlpga, llinlpga_set: 2;
+    /// LMICN left microphone negative input to left PGA negative input path
+    /// control
+    ///
+    /// * `false` = LMICN not connected to PGA negative input (default)
+    /// * `true` = LMICN connected to PGA negative input
+    pub lmicnlpga, lmicnlpga_set: 1;
+    /// LMICP left microphone positive input to left PGA positive input enable
+    ///
+    /// * `false` = LMICP not connected to PGA positive input (default)
+    /// * `true` = LMICP connected to PGA positive input
+    pub lmicplpga, lmicplpga_set: 0;
 }
 
 bitfield! {
@@ -980,7 +1507,35 @@ bitfield! {
     /// [`modify_leftinputpgagain`](crate::Codec::modify_leftinputpgagain)
     pub struct LeftInputPGAGain(u16);
     impl Debug;
-
+    u8;
+    /// PGA volume update bit feature. Write-only bit for synchronized L/R PGA
+    /// changes
+    ///
+    /// * If `false` on [`LeftInputPGAGain`] write, new [`LeftInputPGAGain`]
+    ///   value stored in temporary register If
+    /// * If `true` on [`LeftInputPGAGain`] write, new [`LeftInputPGAGain`]
+    ///   and pending [`RightInputPGAGain`] values become active
+    pub _, lpgau_set: 8;
+    /// Left channel input zero cross detection enable
+    ///
+    /// * `false` = gain changes to PGA register happen immediately (default)
+    /// * `true` = gain changes to PGA happen pending zero crossing logic
+    pub lpgazc, lpgazc_set: 7;
+    /// Left channel mute PGA mute control
+    ///
+    /// * `false` = PGA not muted, normal operation (default)
+    /// * `true` = PGA in muted condition not connected to LADC Mix/Boost stage
+    pub lpgamt, lpgamt_set: 6;
+    /// Left channel input PGA volume control setting. Setting becomes active
+    /// when allowed by zero crossing and/or update bit features. `16` = 0.0 dB
+    /// default setting
+    ///
+    /// * `0` = -12 dB
+    /// * `1` = -11.25 dB
+    /// * *volume changes in 0.75 dB steps per binary bit value*
+    /// * `62` = +34.50 dB
+    /// * `63` = +35.25 dB
+    pub lpgagain, lpgagain_set: 5, 0;
 }
 
 bitfield! {
@@ -991,7 +1546,35 @@ bitfield! {
     /// [`modify_rightinputpgagain`](crate::Codec::modify_rightinputpgagain)
     pub struct RightInputPGAGain(u16);
     impl Debug;
-
+    u8;
+    /// PGA volume update bit feature. Write-only bit for synchronized L/R PGA
+    /// changes
+    ///
+    /// * If `false` on [`RightInputPGAGain`] write, new [`RightInputPGAGain`]
+    ///   value stored in temporary register
+    /// * If `true` on [`RightInputPGAGain`] write, new [`RightInputPGAGain`]
+    /// * and pending [`LeftInputPGAGain`] values become active
+    pub _, rpgau_set: 8;
+    /// Right channel input zero cross detection enable
+    ///
+    /// * `false` = gain changes to PGA register happen immediately
+    /// * `true` = gain changes to PGA happen pending zero crossing logic
+    pub rpgazc, rpgazc_set: 7;
+    /// Right channel mute PGA mute control
+    ///
+    /// * `false` = PGA not muted, normal operation (default)
+    /// * `true` = PGA in muted condition not connected to RADC Mix/Boost stage
+    pub rpgamt, rpgamt_set: 6;
+    /// Right channel input PGA volume control setting. Setting becomes active
+    /// when allowed by zero crossing and/or update bit features. `16` = 0.0 dB
+    /// default setting.
+    ///
+    /// * `0` = -12 dB
+    /// * `1` = -11.25 dB
+    /// * *volume changes in 0.75 dB steps per binary bit value*
+    /// * `62` = +34.50 dB
+    /// * `63` = +35.25 dB
+    pub rpgagain, rpgagain_set: 5, 0;
 }
 
 bitfield! {
@@ -1002,7 +1585,34 @@ bitfield! {
     /// [`modify_leftadcboost`](crate::Codec::modify_leftadcboost)
     pub struct LeftADCBoost(u16);
     impl Debug;
-
+    u8;
+    /// Left channel PGA boost control
+    ///
+    /// * `false` = no gain between PGA output and LPGA Mix/Boost stage input
+    /// * `true` = +20 dB gain between PGA output and LPGA Mix/Boost stage input
+    pub lpgabst, lpgabst_set: 8;
+    /// Gain value between LLIN line input and LPGA Mix/Boost stage input
+    ///
+    /// * `0` = path disconnected (default)
+    /// * `1` = -12 dB
+    /// * `2` = -9.0 dB
+    /// * `3` = -6.0 dB
+    /// * `4` = -3.0 dB
+    /// * `5` = 0.0 dB
+    /// * `6` = +3.0 dB
+    /// * `7` = +6.0 dB
+    pub lpgabstgain, lpgabstgain_set: 6, 4;
+    /// Gain value between LAUXIN auxiliary input and LPGA Mix/Boost stage input
+    ///
+    /// * `0` = path disconnected (default)
+    /// * `1` = -12 dB
+    /// * `2` = -9.0 dB
+    /// * `3` = -6.0 dB
+    /// * `4` = -3.0 dB
+    /// * `5` = 0.0 dB
+    /// * `6` = +3.0 dB
+    /// * `7` = +6.0 dB
+    pub lauxbstgain, lauxbstgain_set: 3, 0;
 }
 
 bitfield! {
@@ -1013,7 +1623,34 @@ bitfield! {
     /// [`modify_rightadcboost`](crate::Codec::modify_rightadcboost)
     pub struct RightADCBoost(u16);
     impl Debug;
-
+    u8;
+    /// Right channel PGA boost control
+    ///
+    /// * `false` = no gain between PGA output and RPGA Mix/Boost stage input
+    /// * `true` = +20 dB gain between PGA output and RPGA Mix/Boost stage input
+    pub rpgabst, rpgabst_set: 8;
+    /// Gain value between RLIN line input and RPGA Mix/Boost stage input
+    ///
+    /// * `0` = path disconnected (default)
+    /// * `1` = -12 dB
+    /// * `2` = -9.0 dB
+    /// * `3` = -6.0 dB
+    /// * `4` = -3.0 dB
+    /// * `5` = 0.0 dB
+    /// * `6` = +3.0 dB
+    /// * `7` = +6.0 dB
+    pub rpgabstgain, rpgabstgain_set: 6, 5;
+    /// Gain value between RAUXIN auxiliary input and RPGA Mix/Boost stage input
+    ///
+    /// * `0` = path disconnected (default)
+    /// * `1` = -12 dB
+    /// * `2` = -9.0 dB
+    /// * `3` = -6.0 dB
+    /// * `4` = -3.0 dB
+    /// * `5` = 0.0 dB
+    /// * `6` = +3.0 dB
+    /// * `7` = +6.0 dB
+    pub rauxbstgain, rauxbstgain_set: 3, 0;
 }
 
 bitfield! {
@@ -1024,7 +1661,48 @@ bitfield! {
     /// [`modify_outputcontrol`](crate::Codec::modify_outputcontrol)
     pub struct OutputControl(u16);
     impl Debug;
-
+    u8;
+    /// Left DAC output to RMIX right output mixer cross-coupling path control
+    ///
+    /// * `false` = path disconnected (default)
+    /// * `true` = path connected
+    pub ldacrmx, ldacrmx_set: 6;
+    /// Right DAC output to LMIX left output mixer cross-coupling path control
+    ///
+    /// * `false` = path disconnected (default)
+    /// * `true` = path connected
+    pub rdaclmx, rdaclmx_set: 5;
+    /// AUXOUT1 gain boost control
+    ///
+    /// * `false` = preferred setting for 3.6V and lower operation, -1.0x gain
+    ///   (default)
+    /// * `true` = required setting for greater than 3.6V operation, +1.5x gain
+    pub aux1bst, aux1bst_set: 4;
+    /// AUXOUT2 gain boost control
+    ///
+    /// * `false` = preferred setting for 3.6V and lower operation, -1.0x gain
+    ///   (default)
+    /// * `true` = required setting for greater than 3.6V operation, +1.5x gain
+    pub aux2bst, aux2bst_set: 3;
+    /// LSPKOUT and RSPKOUT speaker amplifier gain boost control
+    ///
+    /// * `false` = preferred setting for 3.6V and lower operation, -1.0x gain
+    ///   (default)
+    /// * `true` = required setting for greater than 3.6V operation, +1.5x gain
+    pub spkbst, spkbst_set: 2;
+    /// Thermal shutdown enable protects chip from thermal destruction on
+    /// overload
+    ///
+    /// * `false` = disable thermal shutdown (engineering purposes, only)
+    /// * `true` = enable (default) strongly recommended for normal operation
+    pub tsen, tsen_set: 1;
+    /// Output resistance control option for tie-off of unused or disabled
+    /// outputs. Unused outputs tie to internal voltage reference for reduced
+    /// pops and clicks.
+    ///
+    /// * `false` = nominal tie-off impedance value of 1 kΩ (default)
+    /// * `true` = nominal tie-off impedance value of 30 kΩ
+    pub aoutimp, aoutimp_set: 0;
 }
 
 bitfield! {
@@ -1035,7 +1713,47 @@ bitfield! {
     /// [`modify_leftmixer`](crate::Codec::modify_leftmixer)
     pub struct LeftMixer(u16);
     impl Debug;
-
+    u8;
+    /// Gain value between LAUXIN auxiliary input and input to LMAIN left output
+    /// mixer
+    ///
+    /// * `0` = -15 dB (default)
+    /// * `1` = -12 dB
+    /// * `2` = -9.0 dB
+    /// * `3` = -6.0 dB
+    /// * `4` = -3.0 dB
+    /// * `5` = 0.0 dB
+    /// * `6` = +3.0 dB
+    /// * `7` = +6.0 dB
+    pub lauxmxgain, lauxmxgain_set: 8, 6;
+    /// LAUXIN input to LMAIN left output mixer path control
+    ///
+    /// * `false` = LAUXIN not connected to LMAIN left output mixer (default)
+    /// * `true` = LAUXIN connected to LMAIN left output mixer
+    pub lauxlmx, lauxlmx_set: 5;
+    /// Gain value for bypass from LADC Mix/Boost output to LMAIN left output
+    /// mixer.
+    ///
+    /// * `0` = -15 dB (default)
+    /// * `1` = -12 dB
+    /// * `2` = -9.0 dB
+    /// * `3` = -6.0 dB
+    /// * `4` = -3.0 dB
+    /// * `5` = 0.0 dB
+    /// * `6` = +3.0 dB
+    /// * `7` = +6.0 dB
+    pub lbypmxgain, lbypmxgain_set: 4, 2;
+    /// Left bypass path control from LADC Mix/Boost output to LMAIN left output
+    /// mixer
+    ///
+    /// * `false` = path not connected
+    /// * `true` = bypass path connected
+    pub lbyplmx, lbyplmx_set: 1;
+    /// Left DAC output to LMIX left output mixer path control
+    ///
+    /// * `false` = path disconnected (default)
+    /// * `true` = path connected
+    pub ldaclmx, ldaclmx_set: 0;
 }
 
 bitfield! {
@@ -1046,7 +1764,47 @@ bitfield! {
     /// [`modify_rightmixer`](crate::Codec::modify_rightmixer)
     pub struct RightMixer(u16);
     impl Debug;
-
+    u8;
+    /// Gain value between RAUXIN auxiliary input and input to RMAIN left output
+    /// mixer
+    ///
+    /// * `0` = -15 dB (default)
+    /// * `1` = -12 dB
+    /// * `2` = -9.0 dB
+    /// * `3` = -6.0 dB
+    /// * `4` = -3.0 dB
+    /// * `5` = 0.0 dB
+    /// * `6` = +3.0 dB
+    /// * `7` = +6.0 dB
+    pub rauxmxgain, rauxmxgain_set: 8, 6;
+    /// RAUXIN input to RMAIN right output mixer path control
+    ///
+    /// * `false` = RAUXIN not connected to RMAIN right output mixer (default)
+    /// * `true` = RAUXIN connected to RMAIN right output mixer
+    pub rauxrmx, rauxrmx_set: 5;
+    /// Gain value for bypass from RADC Mix/Boost output to RMAIN left output
+    /// mixer.
+    ///
+    /// * `0` = -15 dB (default)
+    /// * `1` = -12 dB
+    /// * `2` = -9.0 dB
+    /// * `3` = -6.0 dB
+    /// * `4` = -3.0 dB
+    /// * `5` = 0.0 dB
+    /// * `6` = +3.0 dB
+    /// * `7` = +6.0 dB
+    pub rbyprmxgain, rbyprmxgain_set: 4, 2;
+    /// Right bypass path control from RADC Mix/Boost output to RMAIN r output
+    /// mixer
+    ///
+    /// * `false` = path not connected
+    /// * `true` = bypass path connected
+    pub rbyprmx, rbyprmx_set: 1;
+    /// Right DAC output to RMIX right output mixer path control
+    ///
+    /// * `false` = path disconnected (default)
+    /// * `true` = path connected
+    pub rdacrmx, rdacrmx_set: 0;
 }
 
 bitfield! {
@@ -1057,7 +1815,38 @@ bitfield! {
     /// [`modify_lhpvolume`](crate::Codec::modify_lhpvolume)
     pub struct LHPVolume(u16);
     impl Debug;
-
+    u8;
+    /// Headphone output volume update bit feature. Write-only bit for
+    /// synchronized changes of left and right headphone amplifier output
+    /// settings
+    ///
+    /// * If `false` on [`LHPVolume`] write, new [`LHPVolume`] value stored in
+    ///   temporary register
+    /// * If `true` on [`LHPVolume`] write, new [`LHPVolume`] and pending
+    ///   [`RHPVolume`] values become active
+    pub lhpvu, lhpvu_set: 8;
+    /// Left channel input zero cross detection enable
+    ///
+    /// * `false` = gain changes to left headphone happen immediately (default)
+    /// * `true` = gain changes to left headphone happen pending zero crossing
+    ///   logic
+    pub lhpzc, lhpzc_set: 7;
+    /// Left headphone output mute control
+    ///
+    /// * `false` = headphone output not muted, normal operation (default)
+    /// * `true` = headphone in muted condition not connected to LMIX output
+    ///   stage
+    pub lhpmute, lhpmute_set: 6;
+    /// Left channel headphone output volume control setting. Setting becomes
+    /// active when allowed by zero crossing and/or update bit features. `57` =
+    /// 0.0 dB default setting.
+    ///
+    /// * `0` = -57 dB
+    /// * `1` = -56 dB
+    /// * *volume changes in 1.0 dB steps per binary bit value*
+    /// * `62` = +5.0 dB
+    /// * `63` = +6.0 dB
+    pub lhpgain, lhpgain_set: 5, 0;
 }
 
 bitfield! {
@@ -1068,7 +1857,38 @@ bitfield! {
     /// [`modify_rhpvolume`](crate::Codec::modify_rhpvolume)
     pub struct RHPVolume(u16);
     impl Debug;
-
+    u8;
+    /// Headphone output volume update bit feature. Write-only bit for
+    /// synchronized changes of left and right headphone amplifier output
+    /// settings
+    ///
+    /// * If `false` on [`RHPVolume`] write, new [`RHPVolume`] value stored in
+    ///   temporary register
+    /// * If `true` on [`RHPVolume`] write, new [`RHPVolume`] and pending
+    ///   [`LHPVolume`] values become active
+    pub rhpvu, rhpvu_set: 8;
+    /// Right channel input zero cross detection enable
+    ///
+    /// * `false` = gain changes to right headphone happen immediately (default)
+    /// * `true` = gain changes to right headphone happen pending zero crossing
+    ///   logic
+    pub rhpzc, rhpzc_set: 7;
+    /// Right headphone output mute control
+    ///
+    /// * `false` = headphone output not muted, normal operation (default)
+    /// * `true` = headphone in muted condition not connected to RMIX output
+    ///   stage
+    pub rhpmute, rhpmute_set: 6;
+    /// Right channel headphone output volume control setting. Setting becomes
+    /// active when allowed by zero crossing and/or update bit features. `57` =
+    /// 0.0 dB default setting.
+    ///
+    /// * `0` = -57 dB
+    /// * `1` = -56 dB
+    /// * *volume changes in 1.0 dB steps per binary bit value*
+    /// * `62` = +5.0 dB
+    /// * `63` = +6.0 dB
+    pub rhpgain, rhpgain_set: 5, 0;
 }
 
 bitfield! {
@@ -1079,6 +1899,39 @@ bitfield! {
     /// [`modify_lspkoutvolume`](crate::Codec::modify_lspkoutvolume)
     pub struct LSPKOUTVolume(u16);
     impl Debug;
+    u8;
+    /// Loudspeaker output volume update bit feature. Write-only bit for
+    /// synchronized changes of left and right headphone amplifier output
+    /// settings
+    ///
+    /// * If `false` on [`LSPKOUTVolume`] write, new [`LSPKOUTVolume`] value
+    ///   stored in temporary register
+    /// * If `true` on [`LSPKOUTVolume`] write, new [`LSPKOUTVolume`] and
+    ///   pending [`RSPKOUTVolume`] values become active
+    pub lspkvu, lspkvu_set: 8;
+    /// Left loudspeaker LSPKOUT output zero cross detection enable
+    ///
+    /// * `false` = gain changes to left loudspeaker happen immediately
+    ///   (default)
+    /// * `true` = gain changes to left loudspeaker happen pending zero crossing
+    ///   logic
+    pub lspkzc, lspkzc_set: 7;
+    /// Right loudspeaker LSPKOUT output mute control
+    ///
+    /// * `false` = loudspeaker output not muted, normal operation (default)
+    /// * `true` = loudspeaker in muted condition
+    pub lspkmute, lspkmute_set: 6;
+    /// Left loudspeaker output volume control setting. Setting becomes active
+    /// when allowed by zero crossing and/or update bit features. `57` = 0.0 dB
+    /// default setting.
+    ///
+    /// * `0` = -57 dB
+    /// * `1` = -56 dB
+    /// * *volume changes in 1.0 dB steps per binary bit value*
+    /// * `62` = +5.0 dB
+    /// * `63` = +6.0 dB
+    pub lspkgain, lspkgain_set: 5, 0;
+
 
 }
 
@@ -1090,7 +1943,38 @@ bitfield! {
     /// [`modify_rspkoutvolume`](crate::Codec::modify_rspkoutvolume)
     pub struct RSPKOUTVolume(u16);
     impl Debug;
-
+    u8;
+    /// Loudspeaker output volume update bit feature. Write-only bit for
+    /// synchronized changes of left and right headphone amplifier output
+    /// settings
+    ///
+    /// * If `false` on [`RSPKOUTVolume`] write, new [`RSPKOUTVolume`] value
+    ///   stored in temporary register
+    /// * If `true` on [`RSPKOUTVolume`] write, new [`RSPKOUTVolume`] and
+    ///   pending [`LSPKOUTVolume`] values become active
+    pub rspkvu, rspkvu_set: 8;
+    /// Right loudspeaker RSPKOUT output zero cross detection enable
+    ///
+    /// * `false` = gain changes to right loudspeaker happen immediately
+    ///   (default)
+    /// * `true` = gain changes to right loudspeaker happen pending zero
+    ///   crossing logic
+    pub rspkzc, rspkzc_set: 7;
+    /// Right loudspeaker RSPKOUT output mute control
+    ///
+    /// * `false` = loudspeaker output not muted, normal operation (default)
+    /// * `true` = loudspeaker in muted condition
+    pub rspkmute, rspkmute_set: 6;
+    /// Right loudspeaker output volume control setting. Setting becomes active
+    /// when allowed by zero crossing and/or update bit features. `57` = 0.0 dB
+    /// default setting.
+    ///
+    /// * `0` = -57 dB
+    /// * `1` = -56 dB
+    /// * *volume changes in 1.0 dB steps per binary bit value*
+    /// * `62` = +5.0 dB
+    /// * `63` = +6.0 dB
+    pub rspkgain, rspkgain_set: 5, 0;
 }
 
 bitfield! {
@@ -1101,7 +1985,32 @@ bitfield! {
     /// [`modify_aux2mixer`](crate::Codec::modify_aux2mixer)
     pub struct AUX2Mixer(u16);
     impl Debug;
-
+    u8;
+    /// AUXOUT2 output mute control
+    ///
+    /// * `false` = output not muted, normal operation (default)
+    /// * `true` = output in muted condition
+    pub auxout2mt, auxout2mt_set: 6;
+    /// AUX1 Mixer output to AUX2 MIXER input path control
+    ///
+    /// * `false` = path not connected
+    /// * `true` = path connected
+    pub aux1mix2, aux1mix2_set: 3;
+    /// Left LADC Mix/Boost output LINMIX path control to AUX2 MIXER input
+    ///
+    /// * `false` = path not connected
+    /// * `true` = path connected
+    pub ladcaux2, ladcaux2_set: 2;
+    /// Left LMAIN MIXER output to AUX2 MIXER input path control
+    ///
+    /// * `false` = path not connected
+    /// * `true` = path connected
+    pub lmixaux2, lmixaux2_set: 1;
+    /// Left DAC output to AUX2 MIXER input path control
+    ///
+    /// * `false` = path not connected
+    /// * `true` = path connected
+    pub ldacaux2, ldacaux2_set: 0;
 }
 
 bitfield! {
@@ -1112,7 +2021,42 @@ bitfield! {
     /// [`modify_aux1mixer`](crate::Codec::modify_aux1mixer)
     pub struct AUX1Mixer(u16);
     impl Debug;
-
+    u8;
+    /// AUXOUT1 output mute control
+    ///
+    /// * `false` = output not muted, normal operation (default)
+    /// * `true` = output in muted condition
+    pub auxout1mt, auxout1mt_set: 6;
+    /// AUXOUT1 6 dB attenuation enable
+    ///
+    /// * `false` = output signal at normal gain value (default)
+    /// * `true` = output signal attenuated by 6.0 dB
+    pub aux1half, aux1half_set: 5;
+    /// Left LMAIN MIXER output to AUX1 MIXER input path control
+    ///
+    /// * `false` = path not connected
+    /// * `true` = path connected
+    pub lmixaux1, lmixaux1_set: 4;
+    /// Left DAC output to AUX1 MIXER input path control
+    ///
+    /// * `false` = path not connected
+    /// * `true` = path connected
+    pub ldacaux1, ldacaux1_set: 3;
+    /// Right RADC Mix/Boost output RINMIX path control to AUX1 MIXER input
+    ///
+    /// * `false` = path not connected
+    /// * `true` = path connected
+    pub radcaux1, radcaux1_set: 2;
+    /// Right RMIX output to AUX1 MIXER input path control
+    ///
+    /// * `false` = path not connected
+    /// * `true` = path connected
+    pub rmixaux1, rmixaux1_set: 1;
+    /// Right DAC output to AUX1 MIXER input path control
+    ///
+    /// * `false` = path not connected
+    /// * `true` = path connected
+    pub rdacaux1, rdacaux1_set: 0;
 }
 
 bitfield! {
@@ -1123,7 +2067,49 @@ bitfield! {
     /// [`modify_powermanagement`](crate::Codec::modify_powermanagement)
     pub struct PowerManagement(u16);
     impl Debug;
-
+    u8;
+    /// Reduce DAC supply current 50% in low power operating mode
+    ///
+    /// * `false` = normal supply current operation (default)
+    /// * `true` = 50% reduced supply current mode
+    pub lpdac, lpdac_set: 8;
+    ///
+    /// Reduce ADC Mix/Boost amplifier supply current 50% in low power operating
+    /// mode
+    ///
+    /// * `false` = normal supply current operation (default)
+    /// * `true` = 50% reduced supply current mode
+    pub lpipbst, lpipbst_set: 7;
+    /// Reduce ADC supply current 50% in low power operating mode
+    ///
+    /// * `false` = normal supply current operation (default)
+    /// * `true` = 50% reduced supply current mode
+    pub lpadc, lpadc_set: 6;
+    /// Reduce loudspeaker amplifier supply current 50% in low power operating
+    /// mode
+    ///
+    /// * `false` = normal supply current operation (default)
+    /// * `true` = 50% reduced supply current mode
+    pub lpspkd, lpspkd_set: 5;
+    /// Microphone bias optional low noise mode configuration control
+    ///
+    /// * `false` = normal configuration with low-Z micbias output impedance
+    /// * `true` = low noise configuration with 200 Ω micbias output impedance
+    pub micbiasm, micbiasm_set: 4;
+    /// Regulator voltage control power reduction options
+    ///
+    /// * `0` = normal 1.80Vdc operation (default)
+    /// * `1` = 1.61Vdc operation
+    /// * `2` = 1.40 Vdc operation
+    /// * `3` = 1.218 Vdc operation
+    pub regvolt, regvolt_set: 3, 2;
+    /// Master bias current power reduction options
+    ///
+    /// * `0` = normal operation (default)
+    /// * `1` = 25% reduced bias current from default
+    /// * `2` = 14% reduced bias current from default
+    /// * `3` = 25% reduced bias current from default
+    pub ibadj, ibadj_set: 1, 0;
 }
 
 bitfield! {
@@ -1134,7 +2120,13 @@ bitfield! {
     /// [`modify_lefttimeslot`](crate::Codec::modify_lefttimeslot)
     pub struct LeftTimeSlot(u16);
     impl Debug;
-
+    u16;
+    /// Left channel PCM time slot start count.
+    ///
+    /// LSB portion of total number of bit times to wait from frame sync before
+    /// clocking audio channel data. LSB portion is combined with MSB from
+    /// [`Misc`] to get total number of bit times to wait.
+    pub ltslot, ltslot_set: 8, 0;
 }
 
 bitfield! {
@@ -1145,7 +2137,42 @@ bitfield! {
     /// [`modify_misc`](crate::Codec::modify_misc)
     pub struct Misc(u16);
     impl Debug;
-
+    u8;
+    /// Time slot function enable for PCM mode.
+    pub pcmtsen, pcmtsen_set: 8;
+    /// Tri state ADC out after second half of LSB enable
+    pub tri, tri_set: 7;
+    /// 8-bit word length enable
+    pub pcm8bit, pcm8bit_set: 6;
+    /// ADCOUT output driver
+    ///
+    /// * `true` = enabled (default)
+    /// * `false` = disabled (driver in high-z state)
+    pub puden, puden_set: 5;
+    /// ADCOUT passive resistor pull-up or passive pull-down enable
+    ///
+    /// * `false` = no passive pull-up or pull-down on ADCOUT pin
+    /// * `true` = passive pull-up resistor on ADCOUT pin if PUDPS = 1
+    /// * `true` = passive pull-down resistor on ADCOUT pin if PUDPS = 0
+    pub pudpe, pudpe_set: 4;
+    /// ADCOUT passive resistor pull-up or pull-down selection
+    ///
+    /// * `false` = passive pull-down resistor applied to ADCOUT pin if PUDPE =
+    ///   1
+    /// * `true` = passive pull-down resistor applied to ADCOUT pin if PUDPE = 1
+    pub pudps, pudps_set: 3;
+    /// Right channel PCM time slot start count.
+    ///
+    /// MSB portion of total number of bit times to wait from frame sync before
+    /// clocking audio channel data. MSB is combined with LSB portion from R61
+    /// ([`RightTimeSlot`]) to get total number of bit times to wait.
+    pub rtslot9, rtslot9_set: 1;
+    /// Left channel PCM time slot start count.
+    ///
+    /// MSB portion of total number of bit times to wait from frame sync before
+    /// clocking audio channel data. MSB is combined with LSB portion from R59
+    /// ([`LeftTimeSlot`]) to get total number of bit times to wait.
+    pub ltslot9, ltslot9_set: 0;
 }
 
 bitfield! {
@@ -1156,7 +2183,13 @@ bitfield! {
     /// [`modify_righttimeslot`](crate::Codec::modify_righttimeslot)
     pub struct RightTimeSlot(u16);
     impl Debug;
-
+    u16;
+    /// Right channel PCM time slot start count.
+    ///
+    /// LSB portion of total number of bit times to wait from frame sync before
+    /// clocking audio channel data. LSB portion is combined with MSB from
+    /// [`Misc`] to get total number of bit times to wait.
+    pub rtslot, rtslot_set: 8, 0;
 }
 
 bitfield! {
@@ -1200,16 +2233,16 @@ bitfield! {
     u8;
     /// Dither added to DAC modulator to eliminate all non-random noise
     ///
-    /// * `0b00000` = dither off
-    /// * `0b10001` = nominal optimal dither
-    /// * `0b11111` = maximum dither
-    pub mod_dither, set_mod_dither: 8, 4;
+    /// * `0` = dither off
+    /// * `17` = nominal optimal dither
+    /// * `31` = maximum dither
+    pub mod_dither, mod_dither_set: 8, 4;
     /// Dither added to DAC analog output to eliminate all non-random noise
     ///
-    /// * `0b0000` = dither off
-    /// * `0b0100` = nominal optimal dither
-    /// * `0b1111` = maximum dither
-    pub analog_dither, set_analog_dither: 3, 0;
+    /// * `0` = dither off
+    /// * `8` = nominal optimal dither
+    /// * `15` = maximum dither
+    pub analog_dither, analog_dither_set: 3, 0;
 }
 
 bitfield! {
@@ -1223,21 +2256,21 @@ bitfield! {
     u8;
     /// Selects one of two tables used to set the target level for the ALC
     ///
-    /// * `false` = default recommended target level table spanning -1.5dB through
-    /// -22.5dB FS
-    /// * `true` = optional ALC target level table spanning -6.0dB through -28.5dB
-    ///   FS
-    pub alctblsel, set_alctblsel: 8;
+    /// * `false` = default recommended target level table spanning -1.5 dB
+    /// through -22.5 dB FS
+    /// * `true` = optional ALC target level table spanning -6.0 dB through
+    ///   -28.5 dB FS
+    pub alctblsel, alctblsel_set: 8;
     /// Choose peak or peak-to-peak value for ALC threshold logic
     ///
     /// * `false` = use rectified peak detector output value
     /// * `true` = use peak-to-peak detector output value
-    pub alcpksel, set_alcpksel: 7;
+    pub alcpksel, alcpksel_set: 7;
     /// Choose peak or peak-to-peak value for Noise Gate threshold logic
     ///
     /// * `false` = use rectified peak detector output value
     /// * `true` = use peak-to-peak detector output value
-    pub alcngsel, set_alcngsel: 6;
+    pub alcngsel, alcngsel_set: 6;
     /// Real time readout of instantaneous gain value used by left channel PGA
     pub alcgainl, _: 5, 0;
 }
@@ -1255,7 +2288,7 @@ bitfield! {
     ///
     /// * `false` = enabled (default)
     /// * `true` = disabled
-    pub pklimena, set_pklimena: 8;
+    pub pklimena, pklimena_set: 8;
     /// Real time readout of instantaneous gain value used by right channel PGA
     pub alcgainl, _: 5, 0;
 }
@@ -1273,24 +2306,24 @@ bitfield! {
     ///
     /// * `false` = normal operation (default)
     /// * `true` = force SPI 4-wire mode regardless of state of Mode pin
-    pub fwspiena, set_fwspiena: 8;
+    pub fwspiena, fwspiena_set: 8;
     /// Short frame sync detection period value
     ///
     /// * `0` = trigger if frame time less than 255 MCLK edges
     /// * `1` = trigger if frame time less than 253 MCLK edges
     /// * `2` = trigger if frame time less than 254 MCLK edges
     /// * `3` = trigger if frame time less than 255 MCLK edges
-    pub fserrval, set_fserrval: 7, 6;
+    pub fserrval, fserrval_set: 7, 6;
     /// Enable DSP state flush on short frame sync event
     ///
     /// * `false` = ignore short frame sync events (default)
     /// * `true` = set DSP state to initial conditions on short frame sync event
-    pub fserflsh, set_fserflsh: 5;
+    pub fserflsh, fserflsh_set: 5;
     /// Enable control for short frame cycle detection logic
     ///
     /// * `false` = short frame cycle detection logic enabled
     /// * `true` = short frame cycle detection logic disabled
-    pub fserrena, set_fserrena: 4;
+    pub fserrena, fserrena_set: 4;
     /// Enable control to delay use of notch filter output when filter is
     /// enabled
     ///
@@ -1298,26 +2331,27 @@ bitfield! {
     ///   enabled (default)
     /// * `true` = use notch filter output immediately after notch filter is
     ///   enabled
-    pub notchdly, set_notchdly: 3;
+    pub notchdly, notchdly_set: 3;
     /// Enable control to mute DAC limiter output when softmute is enabled
     ///
-    /// * `false` = DAC limiter output may not move to exactly zero during Softmute
-    ///   (default)
+    /// * `false` = DAC limiter output may not move to exactly zero during
+    ///   Softmute (default)
     /// * `true` = DAC limiter output muted to exactly zero during softmute
-    pub dacinmute, set_dacinmute: 2;
+    pub dacinmute, dacinmute_set: 2;
     /// Enable control to use PLL output when PLL is not in phase locked
     /// condition
     ///
     /// * `false` = PLL VCO output disabled when PLL is in unlocked condition
     ///   (default)
     /// * `true` = PLL VCO output used as-is when PLL is in unlocked condition
-    pub plllockbp, set_plllockbp: 1;
+    pub plllockbp, plllockbp_set: 1;
     /// Set DAC to use 256x oversampling rate (best at lower sample rates)
     ///
     /// * `false` = Use oversampling rate as determined by Register 0x0A[3]
     ///   (default)
-    /// * `true` = Set DAC to 256x oversampling rate regardless of Register 0x0A[3]
-    pub dacosr256, set_dacosr256: 0;
+    /// * `true` = Set DAC to 256x oversampling rate regardless of Register
+    ///   0x0A[3]
+    pub dacosr256, dacosr256_set: 0;
 }
 
 bitfield! {
@@ -1335,55 +2369,55 @@ bitfield! {
     ///   switching
     /// * `true` = use Register 0x4A bits to override automatic tie-off resistor
     ///   switching
-    pub maninena, set_maninena: 8;
+    pub maninena, maninena_set: 8;
     /// If MANUINEN = 1, use this bit to control right aux input tie-off
     /// resistor switch
     ///
     /// * `false` = Tie-off resistor switch for RAUXIN input is forced open
     /// * `true` = Tie-off resistor switch for RAUXIN input is forced closed
-    pub manraux, set_manraux: 7;
+    pub manraux, manraux_set: 7;
     /// If MANUINEN = 1, use this bit to control right line input tie-off
     /// resistor switch
     ///
     /// * `false` = Tie-off resistor switch for RLIN input is forced open
     /// * `true` = Tie-off resistor switch for RLIN input is forced closed
-    pub manrlin, set_manrlin: 6;
+    pub manrlin, manrlin_set: 6;
     /// If MANUINEN = 1, use this bit to control right PGA inverting input
     /// tie-off switch
     ///
     /// * `false` = Tie-off resistor switch for RMICN input is forced open
     /// * `true` = Tie-off resistor switch for RMICN input is forced closed
-    pub manrmicn, set_manrmicn: 5;
+    pub manrmicn, manrmicn_set: 5;
     /// If MANUINEN =1, use this bit to control right PGA non-inverting input
     /// tie-off switch
     ///
     /// * `false` = Tie-off resistor switch for RMICP input is forced open
     /// * `true` = Tie-off resistor switch for RMICP input is forced closed
-    pub manrmicp, set_manrmicp: 4;
+    pub manrmicp, manrmicp_set: 4;
     /// If MANUINEN = 1, use this bit to control left aux input tie-off resistor
     /// switch
     ///
     /// * `false` = Tie-off resistor switch for LAUXIN input is forced open
     /// * `true` = Tie-off resistor switch for RAUXIN input is forced closed
-    pub manlaux, set_manlaux: 3;
+    pub manlaux, manlaux_set: 3;
     /// If MANUINEN = 1, use this bit to control left line input tie-off
     /// resistor switch
     ///
     /// * `false` = Tie-off resistor switch for LLIN input is forced open
     /// * `true` = Tie-off resistor switch for LLIN input is forced closed
-    pub manllin, set_manllin: 2;
+    pub manllin, manllin_set: 2;
     /// If MANUINEN = 1, use this bit to control left PGA inverting input
     /// tie-off switch
     ///
     /// * `false` = Tie-off resistor switch for LMICN input is forced open
     /// * `true` = Tie-off resistor switch for LMINN input is forced closed
-    pub manlmicn, set_manlmicn: 1;
+    pub manlmicn, manlmicn_set: 1;
     /// If MANUINEN = 1, use this bit to control left PGA non-inverting input
     /// tie-off switch
     ///
     /// * `false` = Tie-off resistor switch for LMICP input is forced open
     /// * `true` = Tie-off resistor switch for LMICP input is forced closed
-    pub manlmicp, set_manlmicp: 0;
+    pub manlmicp, manlmicp_set: 0;
 }
 
 bitfield! {
@@ -1399,46 +2433,46 @@ bitfield! {
     ///
     /// * `false` = normal bias current
     /// * `true` = bias current reduced by 50% for reduced power and bandwidth
-    pub ibthalfi, set_ibthalfi: 8;
+    pub ibthalfi, ibthalfi_set: 8;
     /// Increase bias current to left and right input MIX/BOOST stage
     ///
     /// * `false` = normal bias current
-    /// * `true` = bias current increased by 500 microamps
-    pub ibt500up, set_ibt500up: 6;
+    /// * `true` = bias current increased by 500 µA
+    pub ibt500up, ibt500up_set: 6;
     /// Decrease bias current to left and right input MIX/BOOST stage
     ///
     /// * `false` = normal bias current
-    /// * `true` = bias current reduced by 250 microamps
-    pub ibt250dn, set_ibt250dn: 5;
+    /// * `true` = bias current reduced by 250 µA
+    pub ibt250dn, ibt250dn_set: 5;
     /// Direct manual control to turn on bypass switch around input tie-off
     /// buffer amplifier
     ///
     /// * `false` = normal automatic operation of bypass switch
-    /// * `true` = bypass switch in closed position when input buffer amplifier is
-    ///   disabled
-    pub maninbbp, set_maninbbp: 4;
+    /// * `true` = bypass switch in closed position when input buffer amplifier
+    ///   is disabled
+    pub maninbbp, maninbbp_set: 4;
     /// Direct manual control to turn on switch to ground at input tie-off
     /// buffer amp output
     ///
     /// * `false` = normal automatic operation of switch to ground
     /// * `true` = switch to ground in in closed position when input buffer
     ///   amplifier is disabled
-    pub maninpad, set_maninpad: 3;
-    /// Direct manual control of switch for Vref 600k-ohm resistor to ground
+    pub maninpad, maninpad_set: 3;
+    /// Direct manual control of switch for Vref 600 kΩ resistor to ground
     ///
     /// * `false` = switch to ground controlled by Register 0x01 setting
     /// * `true` = switch to ground in the closed position
-    pub manvrefh, set_manvrefh: 2;
-    /// Direct manual control for switch for Vref 160k-ohm resistor to ground
+    pub manvrefh, manvrefh_set: 2;
+    /// Direct manual control for switch for Vref 160 kΩ resistor to ground
     ///
     /// * `false` = switch to ground controlled by Register 0x01 setting
     /// * `true` = switch to ground in the closed position
-    pub manvrefm, set_manvrefm: 1;
-    /// Direct manual control for switch for Vref 6k-ohm resistor to ground
+    pub manvrefm, manvrefm_set: 1;
+    /// Direct manual control for switch for Vref 6 kΩ resistor to ground
     ///
     /// * `false` = switch to ground controlled by Register 0x01 setting
     /// * `true` = switch to ground in the closed position
-    pub manvrefl, set_manvrefl: 0;
+    pub manvrefl, manvrefl_set: 0;
 }
 
 bitfield! {
@@ -1465,6 +2499,7 @@ bitfield! {
     /// [`modify_peakdetectorread`](crate::Codec::modify_peakdetectorread)
     pub struct PeakDetectorRead(u16);
     impl Debug;
+    u8;
     /// Read-only register which outputs the instantaneous value contained in
     /// the peak detector amplitude register used by the ALC for signal level
     /// dependent logic. Value is highest of left or right input when both
@@ -1480,12 +2515,13 @@ bitfield! {
     /// [`modify_controlandstatus`](crate::Codec::modify_controlandstatus)
     pub struct ControlAndStatus(u16);
     impl Debug;
+    u8;
     /// Select observation point used by DAC output automute feature
     ///
     /// * `false` = automute operates on data at the input to the DAC digital
     ///   attenuator (default)
     /// * `true` = automute operates on data at the DACIN input pin
-    pub amutctrl, set_amutctrl: 5;
+    pub amutctrl, amutctrl_set: 5;
     /// Read-only status bit of high voltage detection circuit monitoring VDDSPK
     /// voltage
     ///
@@ -1530,67 +2566,68 @@ bitfield! {
     /// [`modify_outputtieoffcontrol`](crate::Codec::modify_outputtieoffcontrol)
     pub struct OutputTieOffControl(u16);
     impl Debug;
+    u8;
     /// Enable direct control over output tie-off resistor switching
     ///
     /// * `false` = ignore Register 0x4F bits to control input tie-off
     ///   resistor/buffer switching
     /// * `true` = use Register 0x4F bits to override automatic tie-off
     ///   resistor/buffer switching
-    pub manouten, set_manouten: 8;
-    /// If MANUOUTEN = 1, use this bit to control bypass switch around 1.5x
-    /// boosted output tie-off buffer amplifier
+    pub manouten, manouten_set: 8;
+    /// If `manouten` = `true`, use this bit to control bypass switch around
+    /// 1.5x boosted output tie-off buffer amplifier
     ///
     /// * `false` = normal automatic operation of bypass switch
     /// * `true` = bypass switch in closed position when output buffer amplifier
     ///   is disabled
-    pub shrtbufh, set_shrtbufh: 7;
-    /// If MANUOUTEN = 1, use this bit to control bypass switch around 1.0x
-    /// non-boosted output tie-off buffer amplifier
+    pub shrtbufh, shrtbufh_set: 7;
+    /// If `manouten` = `true`, use this bit to control bypass switch around
+    /// 1.0x non-boosted output tie-off buffer amplifier
     ///
     /// * `false` = normal automatic operation of bypass switch
-    /// * `true` = bypass switch in closed position when output buffer amplifier is
-    ///   disabled
-    pub shrtbufl, set_shrtbufl: 6;
-    /// If MANUOUTEN = 1, use this bit to control left speaker output tie-off
-    /// resistor switch
+    /// * `true` = bypass switch in closed position when output buffer amplifier
+    ///   is disabled
+    pub shrtbufl, shrtbufl_set: 6;
+    /// If `manouten` = `true`, use this bit to control left speaker output
+    /// tie-off resistor switch
     ///
     /// * `false` = tie-off resistor switch for LSPKOUT speaker output is forced
     ///   open
     /// * `true` = tie-off resistor switch for LSPKOUT speaker output is forced
     ///   closed
-    pub shrtlspk, set_shrtlspk: 5;
-    /// If MANUOUTEN = 1, use this bit to control left speaker output tie-off
-    /// resistor switch
+    pub shrtlspk, shrtlspk_set: 5;
+    /// If `manouten` = `true`, use this bit to control left speaker output
+    /// tie-off resistor switch
     ///
     /// * `false` = tie-off resistor switch for RSPKOUT speaker output is forced
     ///   open
     /// * `true` = tie-off resistor switch for RSPKOUT speaker output is forced
     ///   closed
-    pub shrtrspk, set_shrtrspk: 4;
-    /// If MANUOUTEN = 1, use this bit to control Auxout1 output tie-off
+    pub shrtrspk, shrtrspk_set: 4;
+    /// If `manouten` = `true`, use this bit to control Auxout1 output tie-off
     /// resistor switch
     ///
     /// * `false` = tie-off resistor switch for AUXOUT1 output is forced open
     /// * `true` = tie-off resistor switch for AUXOUT1 output is forced closed
-    pub shrtaux1, set_shrtaux1: 3;
-    /// If MANUOUTEN = 1, use this bit to control Auxout2 output tie-off
+    pub shrtaux1, shrtaux1_set: 3;
+    /// If `manouten` = `true`, use this bit to control Auxout2 output tie-off
     /// resistor switch
     ///
     /// * `false` = tie-off resistor switch for AUXOUT2 output is forced open
     /// * `true` = tie-off resistor switch for AUXOUT2 output is forced closed
-    pub shrtaux2, set_shrtaux2: 2;
-    /// If MANUOUTEN = 1, use this bit to control left headphone output tie-off
-    /// switch
+    pub shrtaux2, shrtaux2_set: 2;
+    /// If `manouten` = `true`, use this bit to control left headphone output
+    /// tie-off switch
     ///
     /// * `false` = tie-off resistor switch for LHP output is forced open
     /// * `true` = tie-off resistor switch for LHP output is forced closed
-    pub shrtlhp, set_shrtlhp: 1;
-    /// If MANUOUTEN = 1, use this bit to control right headphone output tie-off
-    /// switch
+    pub shrtlhp, shrtlhp_set: 1;
+    /// If `manouten` = `true`, use this bit to control right headphone output
+    /// tie-off switch
     ///
     /// * `false` = tie-off resistor switch for RHP output is forced open
     /// * `true` = tie-off resistor switch for RHP output is forced closed
-    pub shrtrhp, set_shrtrhp: 0;
+    pub shrtrhp, shrtrhp_set: 0;
 }
 
 // End of file

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -151,6 +151,10 @@ pub enum Register {
 
 bitfield! {
     /// Power Management 1 register contents
+    ///
+    /// See [`read_powermanagement1`](crate::Codec::read_powermanagement1),
+    /// [`write_powermanagement1`](crate::Codec::write_powermanagement1) and
+    /// [`modify_powermanagement1`](crate::Codec::modify_powermanagement1)
     pub struct PowerManagement1(u16);
     impl Debug;
     u8;
@@ -200,6 +204,10 @@ bitfield! {
 
 bitfield! {
     /// Power Management 2 register contents
+    ///
+    /// See [`read_powermanagement2`](crate::Codec::read_powermanagement2),
+    /// [`write_powermanagement2`](crate::Codec::write_powermanagement2) and
+    /// [`modify_powermanagement2`](crate::Codec::modify_powermanagement2)
     pub struct PowerManagement2(u16);
     impl Debug;
     u8;
@@ -252,6 +260,10 @@ bitfield! {
 
 bitfield! {
     /// Power Management 3 register contents
+    ///
+    /// See [`read_powermanagement3`](crate::Codec::read_powermanagement3),
+    /// [`write_powermanagement3`](crate::Codec::write_powermanagement3) and
+    /// [`modify_powermanagement3`](crate::Codec::modify_powermanagement3)
     pub struct PowerManagement3(u16);
     impl Debug;
     /// AUXOUT1 analog output power control, pin#21
@@ -298,6 +310,10 @@ bitfield! {
 
 bitfield! {
     /// Audio Interface register contents
+    ///
+    /// See [`read_audiointerface`](crate::Codec::read_audiointerface),
+    /// [`write_audiointerface`](crate::Codec::write_audiointerface) and
+    /// [`modify_audiointerface`](crate::Codec::modify_audiointerface)
     pub struct AudioInterface(u16);
     impl Debug;
     u8;
@@ -316,17 +332,17 @@ bitfield! {
     pub lrp, set_lrp: 7;
     /// Word length (24-bits default) of audio data stream
     ///
-    /// * `00` = 16-bit word length
-    /// * `01` = 20-bit word length
-    /// * `10` = 24-bit word length
-    /// * `11` = 32-bit word length
+    /// * `0` = 16-bit word length
+    /// * `1` = 20-bit word length
+    /// * `2` = 24-bit word length
+    /// * `3` = 32-bit word length
     pub wlen, set_wlen: 6,5;
     /// Audio interface data format (default setting is I2S)
     ///
-    /// * `00` = right justified
-    /// * `01` = left justified
-    /// * `10` = standard I2S format
-    /// * `11` = PCMA or PCMB audio data format option
+    /// * `0` = right justified
+    /// * `1` = left justified
+    /// * `2` = standard I2S format
+    /// * `3` = PCMA or PCMB audio data format option
     pub aifmt, set_aifmt: 4,3;
     /// DAC audio data left-right ordering
     ///
@@ -370,6 +386,10 @@ impl From<u8> for CompandingMode {
 
 bitfield! {
     /// Companding register contents
+    ///
+    /// See [`read_companding`](crate::Codec::read_companding),
+    /// [`write_companding`](crate::Codec::write_companding) and
+    /// [`modify_companding`](crate::Codec::modify_companding)
     pub struct Companding(u16);
     impl Debug;
     u8;
@@ -401,6 +421,10 @@ bitfield! {
 
 bitfield! {
     /// Clock Control 1 register contents
+    ///
+    /// See [`read_clockcontrol1`](crate::Codec::read_clockcontrol1),
+    /// [`write_clockcontrol1`](crate::Codec::write_clockcontrol1) and
+    /// [`modify_clockcontrol1`](crate::Codec::modify_clockcontrol1)
     pub struct ClockControl1(u16);
     impl Debug;
     u8;
@@ -421,22 +445,27 @@ bitfield! {
     /// * `7` = divide by 12
     pub mclksel, set_mclksel: 7, 5;
     /// Scaling of output frequency at BCLK pin#8 when chip is in master mode
-    /// `0` = divide by 1
-    /// `1` = divide by 2
-    /// `2` = divide by 4
-    /// `3` = divide by 8
-    /// `4` = divide by 16
-    /// `5` = divide by 32
+    ///
+    /// * `0` = divide by 1
+    /// * `1` = divide by 2
+    /// * `2` = divide by 4
+    /// * `3` = divide by 8
+    /// * `4` = divide by 16
+    /// * `5` = divide by 32
     pub bclksel, set_bclksel: 4, 2;
     /// Enables chip master mode to drive FS and BCLK outputs
     ///
-    /// `false` = FS and BCLK are inputs
-    /// `true` = FS and BCLK are driven as outputs by internally generated clocks
+    /// * `false` = FS and BCLK are inputs
+    /// * `true` = FS and BCLK are driven as outputs by internally generated clocks
     pub clkioen, set_clkioen: 0;
 }
 
 bitfield! {
     /// Clock Control 2 register contents
+    ///
+    /// See [`read_clockcontrol2`](crate::Codec::read_clockcontrol2),
+    /// [`write_clockcontrol2`](crate::Codec::write_clockcontrol2) and
+    /// [`modify_clockcontrol2`](crate::Codec::modify_clockcontrol2)
     pub struct ClockControl2(u16);
     impl Debug;
     /// 4-wire control interface enable
@@ -503,6 +532,10 @@ impl From<u8> for Gpio1Selection {
 
 bitfield! {
     /// GPIO register contents
+    ///
+    /// See [`read_gpio`](crate::Codec::read_gpio),
+    /// [`write_gpio`](crate::Codec::write_gpio) and
+    /// [`modify_gpio`](crate::Codec::modify_gpio)
     pub struct GPIO(u16);
     impl Debug;
     u8;
@@ -515,8 +548,8 @@ bitfield! {
     pub gpio1pll, set_gpio1pll: 5, 4;
     /// GPIO1 polarity inversion control
     ///
-    /// * `0` = normal logic sense of GPIO signal
-    /// * `1` = inverted logic sense of GPIO signal
+    /// * `false` = normal logic sense of GPIO signal
+    /// * `true` = inverted logic sense of GPIO signal
     pub gpio1pl, set_gpio1pl: 3;
     /// CSB/GPIO1 function select (input default)
     ///
@@ -533,6 +566,10 @@ bitfield! {
 
 bitfield! {
     /// Jack Detect 1 register contents
+    ///
+    /// See [`read_jackdetect1`](crate::Codec::read_jackdetect1),
+    /// [`write_jackdetect1`](crate::Codec::write_jackdetect1) and
+    /// [`modify_jackdetect1`](crate::Codec::modify_jackdetect1)
     pub struct JackDetect1(u16);
     impl Debug;
     u8;
@@ -546,52 +583,60 @@ bitfield! {
     pub jckmiden, set_jckmiden: 8, 7;
     /// Jack detection feature enable
     ///
-    /// `false` = disabled
-    /// `true` = enable jack detection associated functionality
+    /// * `false` = disabled
+    /// * `true` = enable jack detection associated functionality
     pub jacden, set_jacden: 6;
     /// Select jack detect pin (GPIO1 default)
     ///
-    /// `0` = GPIO1 is used for jack detection feature
-    /// `1` = GPIO2 is used for jack detection feature
-    /// `2` = GPIO3 is used for jack detection feature
-    /// `3` = reserved
+    /// * `0` = GPIO1 is used for jack detection feature
+    /// * `1` = GPIO2 is used for jack detection feature
+    /// * `2` = GPIO3 is used for jack detection feature
+    /// * `3` = reserved
     pub jckdio, set_jckdio: 5, 4;
 }
 
 bitfield! {
     /// DAC Control register contents
+    ///
+    /// See [`read_daccontrol`](crate::Codec::read_daccontrol),
+    /// [`write_daccontrol`](crate::Codec::write_daccontrol) and
+    /// [`modify_daccontrol`](crate::Codec::modify_daccontrol)
     pub struct DACControl(u16);
     impl Debug;
     u8;
     /// Softmute feature control for DACs
     ///
-    /// `false` = disabled
-    /// `true` = enabled
+    /// * `false` = disabled
+    /// * `true` = enabled
     pub softmt, set_softmt: 6;
     /// DAC oversampling rate selection (64X default)
     ///
-    /// `false` = 64x oversampling
-    /// `true` = 128x oversampling
+    /// * `false` = 64x oversampling
+    /// * `true` = 128x oversampling
     pub dacos, set_dacos: 3;
     /// DAC automute function enable
     ///
-    /// `false` = disabled
-    /// `true` = enabled
+    /// * `false` = disabled
+    /// * `true` = enabled
     pub automt, set_automt: 2;
     /// DAC right channel output polarity control
     ///
-    /// `false` = normal polarity
-    /// `true` = inverted polarity
+    /// * `false` = normal polarity
+    /// * `true` = inverted polarity
     pub rdacpl, set_rdacpl: 1;
     /// DAC left channel output polarity control
     ///
-    /// `false` = normal polarity
-    /// `true` = inverted polarity
+    /// * `false` = normal polarity
+    /// * `true` = inverted polarity
     pub ldacpl, set_ldacpl: 0;
 }
 
 bitfield! {
     /// Left DAC Volume register contents
+    ///
+    /// See [`read_leftdacvolume`](crate::Codec::read_leftdacvolume),
+    /// [`write_leftdacvolume`](crate::Codec::write_leftdacvolume) and
+    /// [`modify_leftdacvolume`](crate::Codec::modify_leftdacvolume)
     pub struct LeftDACVolume(u16);
     impl Debug;
     u8;
@@ -615,6 +660,10 @@ bitfield! {
 
 bitfield! {
     /// Right DAC Volume register contents
+    ///
+    /// See [`read_rightdacvolume`](crate::Codec::read_rightdacvolume),
+    /// [`write_rightdacvolume`](crate::Codec::write_rightdacvolume) and
+    /// [`modify_rightdacvolume`](crate::Codec::modify_rightdacvolume)
     pub struct RightDACVolume(u16);
     impl Debug;
     /// DAC volume update bit feature. Write-only bit for synchronized L/R DAC
@@ -637,6 +686,10 @@ bitfield! {
 
 bitfield! {
     /// Jack Detect 2 register contents
+    ///
+    /// See [`read_jackdetect2`](crate::Codec::read_jackdetect2),
+    /// [`write_jackdetect2`](crate::Codec::write_jackdetect2) and
+    /// [`modify_jackdetect2`](crate::Codec::modify_jackdetect2)
     pub struct JackDetect2(u16);
     impl Debug;
 
@@ -644,6 +697,10 @@ bitfield! {
 
 bitfield! {
     /// ADC Control register contents
+    ///
+    /// See [`read_adccontrol`](crate::Codec::read_adccontrol),
+    /// [`write_adccontrol`](crate::Codec::write_adccontrol) and
+    /// [`modify_adccontrol`](crate::Codec::modify_adccontrol)
     pub struct ADCControl(u16);
     impl Debug;
 
@@ -651,6 +708,10 @@ bitfield! {
 
 bitfield! {
     /// Left ADC Volume register contents
+    ///
+    /// See [`read_leftadcvolume`](crate::Codec::read_leftadcvolume),
+    /// [`write_leftadcvolume`](crate::Codec::write_leftadcvolume) and
+    /// [`modify_leftadcvolume`](crate::Codec::modify_leftadcvolume)
     pub struct LeftADCVolume(u16);
     impl Debug;
 
@@ -658,6 +719,10 @@ bitfield! {
 
 bitfield! {
     /// Right ADC Volume register contents
+    ///
+    /// See [`read_rightadcvolume`](crate::Codec::read_rightadcvolume),
+    /// [`write_rightadcvolume`](crate::Codec::write_rightadcvolume) and
+    /// [`modify_rightadcvolume`](crate::Codec::modify_rightadcvolume)
     pub struct RightADCVolume(u16);
     impl Debug;
 
@@ -665,6 +730,10 @@ bitfield! {
 
 bitfield! {
     /// EQ1-high cutoff register contents
+    ///
+    /// See [`read_eq1highcutoff`](crate::Codec::read_eq1highcutoff),
+    /// [`write_eq1highcutoff`](crate::Codec::write_eq1highcutoff) and
+    /// [`modify_eq1highcutoff`](crate::Codec::modify_eq1highcutoff)
     pub struct EQ1HighCutoff(u16);
     impl Debug;
 
@@ -672,6 +741,10 @@ bitfield! {
 
 bitfield! {
     /// EQ2-peak 1 register contents
+    ///
+    /// See [`read_eq2peak1`](crate::Codec::read_eq2peak1),
+    /// [`write_eq2peak1`](crate::Codec::write_eq2peak1) and
+    /// [`modify_eq2peak1`](crate::Codec::modify_eq2peak1)
     pub struct EQ2Peak1(u16);
     impl Debug;
 
@@ -679,6 +752,10 @@ bitfield! {
 
 bitfield! {
     /// EQ3-peak 2 register contents
+    ///
+    /// See [`read_eq3peak2`](crate::Codec::read_eq3peak2),
+    /// [`write_eq3peak2`](crate::Codec::write_eq3peak2) and
+    /// [`modify_eq3peak2`](crate::Codec::modify_eq3peak2)
     pub struct EQ3Peak2(u16);
     impl Debug;
 
@@ -686,6 +763,10 @@ bitfield! {
 
 bitfield! {
     /// EQ4-peak 3 register contents
+    ///
+    /// See [`read_eq4peak3`](crate::Codec::read_eq4peak3),
+    /// [`write_eq4peak3`](crate::Codec::write_eq4peak3) and
+    /// [`modify_eq4peak3`](crate::Codec::modify_eq4peak3)
     pub struct EQ4Peak3(u16);
     impl Debug;
 
@@ -693,6 +774,10 @@ bitfield! {
 
 bitfield! {
     /// EQ5-low cutoff register contents
+    ///
+    /// See [`read_eq5lowcutoff`](crate::Codec::read_eq5lowcutoff),
+    /// [`write_eq5lowcutoff`](crate::Codec::write_eq5lowcutoff) and
+    /// [`modify_eq5lowcutoff`](crate::Codec::modify_eq5lowcutoff)
     pub struct EQ5LowCutoff(u16);
     impl Debug;
 
@@ -700,6 +785,10 @@ bitfield! {
 
 bitfield! {
     /// DAC Limiter 1 register contents
+    ///
+    /// See [`read_daclimiter1`](crate::Codec::read_daclimiter1),
+    /// [`write_daclimiter1`](crate::Codec::write_daclimiter1) and
+    /// [`modify_daclimiter1`](crate::Codec::modify_daclimiter1)
     pub struct DACLimiter1(u16);
     impl Debug;
 
@@ -707,6 +796,10 @@ bitfield! {
 
 bitfield! {
     /// DAC Limiter 2 register contents
+    ///
+    /// See [`read_daclimiter2`](crate::Codec::read_daclimiter2),
+    /// [`write_daclimiter2`](crate::Codec::write_daclimiter2) and
+    /// [`modify_daclimiter2`](crate::Codec::modify_daclimiter2)
     pub struct DACLimiter2(u16);
     impl Debug;
 
@@ -714,6 +807,10 @@ bitfield! {
 
 bitfield! {
     /// Notch Filter 1 register contents
+    ///
+    /// See [`read_notchfilter1`](crate::Codec::read_notchfilter1),
+    /// [`write_notchfilter1`](crate::Codec::write_notchfilter1) and
+    /// [`modify_notchfilter1`](crate::Codec::modify_notchfilter1)
     pub struct NotchFilter1(u16);
     impl Debug;
 
@@ -721,6 +818,10 @@ bitfield! {
 
 bitfield! {
     /// Notch Filter 2 register contents
+    ///
+    /// See [`read_notchfilter2`](crate::Codec::read_notchfilter2),
+    /// [`write_notchfilter2`](crate::Codec::write_notchfilter2) and
+    /// [`modify_notchfilter2`](crate::Codec::modify_notchfilter2)
     pub struct NotchFilter2(u16);
     impl Debug;
 
@@ -728,6 +829,10 @@ bitfield! {
 
 bitfield! {
     /// Notch Filter 3 register contents
+    ///
+    /// See [`read_notchfilter3`](crate::Codec::read_notchfilter3),
+    /// [`write_notchfilter3`](crate::Codec::write_notchfilter3) and
+    /// [`modify_notchfilter3`](crate::Codec::modify_notchfilter3)
     pub struct NotchFilter3(u16);
     impl Debug;
 
@@ -735,6 +840,10 @@ bitfield! {
 
 bitfield! {
     /// Notch Filter 4 register contents
+    ///
+    /// See [`read_notchfilter4`](crate::Codec::read_notchfilter4),
+    /// [`write_notchfilter4`](crate::Codec::write_notchfilter4) and
+    /// [`modify_notchfilter4`](crate::Codec::modify_notchfilter4)
     pub struct NotchFilter4(u16);
     impl Debug;
 
@@ -742,6 +851,10 @@ bitfield! {
 
 bitfield! {
     /// ALC Control 1 register contents
+    ///
+    /// See [`read_alccontrol1`](crate::Codec::read_alccontrol1),
+    /// [`write_alccontrol1`](crate::Codec::write_alccontrol1) and
+    /// [`modify_alccontrol1`](crate::Codec::modify_alccontrol1)
     pub struct ALCControl1(u16);
     impl Debug;
 
@@ -749,6 +862,10 @@ bitfield! {
 
 bitfield! {
     /// ALC Control 2 register contents
+    ///
+    /// See [`read_alccontrol2`](crate::Codec::read_alccontrol2),
+    /// [`write_alccontrol2`](crate::Codec::write_alccontrol2) and
+    /// [`modify_alccontrol2`](crate::Codec::modify_alccontrol2)
     pub struct ALCControl2(u16);
     impl Debug;
 
@@ -756,6 +873,10 @@ bitfield! {
 
 bitfield! {
     /// ALC Control 3 register contents
+    ///
+    /// See [`read_alccontrol3`](crate::Codec::read_alccontrol3),
+    /// [`write_alccontrol3`](crate::Codec::write_alccontrol3) and
+    /// [`modify_alccontrol3`](crate::Codec::modify_alccontrol3)
     pub struct ALCControl3(u16);
     impl Debug;
 
@@ -763,6 +884,10 @@ bitfield! {
 
 bitfield! {
     /// Noise Gate register contents
+    ///
+    /// See [`read_noisegate`](crate::Codec::read_noisegate),
+    /// [`write_noisegate`](crate::Codec::write_noisegate) and
+    /// [`modify_noisegate`](crate::Codec::modify_noisegate)
     pub struct NoiseGate(u16);
     impl Debug;
 
@@ -770,6 +895,10 @@ bitfield! {
 
 bitfield! {
     /// PLL N register contents
+    ///
+    /// See [`read_plln`](crate::Codec::read_plln),
+    /// [`write_plln`](crate::Codec::write_plln) and
+    /// [`modify_plln`](crate::Codec::modify_plln)
     pub struct PllN(u16);
     impl Debug;
 
@@ -777,6 +906,10 @@ bitfield! {
 
 bitfield! {
     /// PLL K 1 register contents
+    ///
+    /// See [`read_pllk1`](crate::Codec::read_pllk1),
+    /// [`write_pllk1`](crate::Codec::write_pllk1) and
+    /// [`modify_pllk1`](crate::Codec::modify_pllk1)
     pub struct PllK1(u16);
     impl Debug;
 
@@ -784,6 +917,10 @@ bitfield! {
 
 bitfield! {
     /// PLL K 2 register contents
+    ///
+    /// See [`read_pllk2`](crate::Codec::read_pllk2),
+    /// [`write_pllk2`](crate::Codec::write_pllk2) and
+    /// [`modify_pllk2`](crate::Codec::modify_pllk2)
     pub struct PllK2(u16);
     impl Debug;
 
@@ -791,6 +928,10 @@ bitfield! {
 
 bitfield! {
     /// PLL K 3 register contents
+    ///
+    /// See [`read_pllk3`](crate::Codec::read_pllk3),
+    /// [`write_pllk3`](crate::Codec::write_pllk3) and
+    /// [`modify_pllk3`](crate::Codec::modify_pllk3)
     pub struct PllK3(u16);
     impl Debug;
 
@@ -798,6 +939,10 @@ bitfield! {
 
 bitfield! {
     /// 3D control register contents
+    ///
+    /// See [`read_threedcontrol`](crate::Codec::read_threedcontrol),
+    /// [`write_threedcontrol`](crate::Codec::write_threedcontrol) and
+    /// [`modify_threedcontrol`](crate::Codec::modify_threedcontrol)
     pub struct ThreeDControl(u16);
     impl Debug;
 
@@ -805,6 +950,10 @@ bitfield! {
 
 bitfield! {
     /// Right Speaker Submix register contents
+    ///
+    /// See [`read_rightspeakersubmix`](crate::Codec::read_rightspeakersubmix),
+    /// [`write_rightspeakersubmix`](crate::Codec::write_rightspeakersubmix) and
+    /// [`modify_rightspeakersubmix`](crate::Codec::modify_rightspeakersubmix)
     pub struct RightSpeakerSubmix(u16);
     impl Debug;
 
@@ -812,6 +961,10 @@ bitfield! {
 
 bitfield! {
     /// Input Control register contents
+    ///
+    /// See [`read_inputcontrol`](crate::Codec::read_inputcontrol),
+    /// [`write_inputcontrol`](crate::Codec::write_inputcontrol) and
+    /// [`modify_inputcontrol`](crate::Codec::modify_inputcontrol)
     pub struct InputControl(u16);
     impl Debug;
 
@@ -819,6 +972,10 @@ bitfield! {
 
 bitfield! {
     /// Left Input PGA Gain register contents
+    ///
+    /// See [`read_leftinputpgagain`](crate::Codec::read_leftinputpgagain),
+    /// [`write_leftinputpgagain`](crate::Codec::write_leftinputpgagain) and
+    /// [`modify_leftinputpgagain`](crate::Codec::modify_leftinputpgagain)
     pub struct LeftInputPGAGain(u16);
     impl Debug;
 
@@ -826,6 +983,10 @@ bitfield! {
 
 bitfield! {
     /// Right Input PGA Gain register contents
+    ///
+    /// See [`read_rightinputpgagain`](crate::Codec::read_rightinputpgagain),
+    /// [`write_rightinputpgagain`](crate::Codec::write_rightinputpgagain) and
+    /// [`modify_rightinputpgagain`](crate::Codec::modify_rightinputpgagain)
     pub struct RightInputPGAGain(u16);
     impl Debug;
 
@@ -833,6 +994,10 @@ bitfield! {
 
 bitfield! {
     /// Left ADC Boost register contents
+    ///
+    /// See [`read_leftadcboost`](crate::Codec::read_leftadcboost),
+    /// [`write_leftadcboost`](crate::Codec::write_leftadcboost) and
+    /// [`modify_leftadcboost`](crate::Codec::modify_leftadcboost)
     pub struct LeftADCBoost(u16);
     impl Debug;
 
@@ -840,6 +1005,10 @@ bitfield! {
 
 bitfield! {
     /// Right ADC Boost register contents
+    ///
+    /// See [`read_rightadcboost`](crate::Codec::read_rightadcboost),
+    /// [`write_rightadcboost`](crate::Codec::write_rightadcboost) and
+    /// [`modify_rightadcboost`](crate::Codec::modify_rightadcboost)
     pub struct RightADCBoost(u16);
     impl Debug;
 
@@ -847,6 +1016,10 @@ bitfield! {
 
 bitfield! {
     /// Output Control register contents
+    ///
+    /// See [`read_outputcontrol`](crate::Codec::read_outputcontrol),
+    /// [`write_outputcontrol`](crate::Codec::write_outputcontrol) and
+    /// [`modify_outputcontrol`](crate::Codec::modify_outputcontrol)
     pub struct OutputControl(u16);
     impl Debug;
 
@@ -854,6 +1027,10 @@ bitfield! {
 
 bitfield! {
     /// Left Mixer register contents
+    ///
+    /// See [`read_leftmixer`](crate::Codec::read_leftmixer),
+    /// [`write_leftmixer`](crate::Codec::write_leftmixer) and
+    /// [`modify_leftmixer`](crate::Codec::modify_leftmixer)
     pub struct LeftMixer(u16);
     impl Debug;
 
@@ -861,6 +1038,10 @@ bitfield! {
 
 bitfield! {
     /// Right Mixer register contents
+    ///
+    /// See [`read_rightmixer`](crate::Codec::read_rightmixer),
+    /// [`write_rightmixer`](crate::Codec::write_rightmixer) and
+    /// [`modify_rightmixer`](crate::Codec::modify_rightmixer)
     pub struct RightMixer(u16);
     impl Debug;
 
@@ -868,6 +1049,10 @@ bitfield! {
 
 bitfield! {
     /// LHP Volume register contents
+    ///
+    /// See [`read_lhpvolume`](crate::Codec::read_lhpvolume),
+    /// [`write_lhpvolume`](crate::Codec::write_lhpvolume) and
+    /// [`modify_lhpvolume`](crate::Codec::modify_lhpvolume)
     pub struct LHPVolume(u16);
     impl Debug;
 
@@ -875,6 +1060,10 @@ bitfield! {
 
 bitfield! {
     /// RHP Volume register contents
+    ///
+    /// See [`read_rhpvolume`](crate::Codec::read_rhpvolume),
+    /// [`write_rhpvolume`](crate::Codec::write_rhpvolume) and
+    /// [`modify_rhpvolume`](crate::Codec::modify_rhpvolume)
     pub struct RHPVolume(u16);
     impl Debug;
 
@@ -882,6 +1071,10 @@ bitfield! {
 
 bitfield! {
     /// LSPKOUT Volume register contents
+    ///
+    /// See [`read_lspkoutvolume`](crate::Codec::read_lspkoutvolume),
+    /// [`write_lspkoutvolume`](crate::Codec::write_lspkoutvolume) and
+    /// [`modify_lspkoutvolume`](crate::Codec::modify_lspkoutvolume)
     pub struct LSPKOUTVolume(u16);
     impl Debug;
 
@@ -889,6 +1082,10 @@ bitfield! {
 
 bitfield! {
     /// RSPKOUT Volume register contents
+    ///
+    /// See [`read_rspkoutvolume`](crate::Codec::read_rspkoutvolume),
+    /// [`write_rspkoutvolume`](crate::Codec::write_rspkoutvolume) and
+    /// [`modify_rspkoutvolume`](crate::Codec::modify_rspkoutvolume)
     pub struct RSPKOUTVolume(u16);
     impl Debug;
 
@@ -896,6 +1093,10 @@ bitfield! {
 
 bitfield! {
     /// AUX2 Mixer register contents
+    ///
+    /// See [`read_aux2mixer`](crate::Codec::read_aux2mixer),
+    /// [`write_aux2mixer`](crate::Codec::write_aux2mixer) and
+    /// [`modify_aux2mixer`](crate::Codec::modify_aux2mixer)
     pub struct AUX2Mixer(u16);
     impl Debug;
 
@@ -903,6 +1104,10 @@ bitfield! {
 
 bitfield! {
     /// AUX1 Mixer register contents
+    ///
+    /// See [`read_aux1mixer`](crate::Codec::read_aux1mixer),
+    /// [`write_aux1mixer`](crate::Codec::write_aux1mixer) and
+    /// [`modify_aux1mixer`](crate::Codec::modify_aux1mixer)
     pub struct AUX1Mixer(u16);
     impl Debug;
 
@@ -910,6 +1115,10 @@ bitfield! {
 
 bitfield! {
     /// Power Management register contents
+    ///
+    /// See [`read_powermanagement`](crate::Codec::read_powermanagement),
+    /// [`write_powermanagement`](crate::Codec::write_powermanagement) and
+    /// [`modify_powermanagement`](crate::Codec::modify_powermanagement)
     pub struct PowerManagement(u16);
     impl Debug;
 
@@ -917,6 +1126,10 @@ bitfield! {
 
 bitfield! {
     /// Left Time Slot register contents
+    ///
+    /// See [`read_lefttimeslot`](crate::Codec::read_lefttimeslot),
+    /// [`write_lefttimeslot`](crate::Codec::write_lefttimeslot) and
+    /// [`modify_lefttimeslot`](crate::Codec::modify_lefttimeslot)
     pub struct LeftTimeSlot(u16);
     impl Debug;
 
@@ -924,6 +1137,10 @@ bitfield! {
 
 bitfield! {
     /// Misc register contents
+    ///
+    /// See [`read_misc`](crate::Codec::read_misc),
+    /// [`write_misc`](crate::Codec::write_misc) and
+    /// [`modify_misc`](crate::Codec::modify_misc)
     pub struct Misc(u16);
     impl Debug;
 
@@ -931,6 +1148,10 @@ bitfield! {
 
 bitfield! {
     /// Right Time Slot register contents
+    ///
+    /// See [`read_righttimeslot`](crate::Codec::read_righttimeslot),
+    /// [`write_righttimeslot`](crate::Codec::write_righttimeslot) and
+    /// [`modify_righttimeslot`](crate::Codec::modify_righttimeslot)
     pub struct RightTimeSlot(u16);
     impl Debug;
 

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -129,6 +129,8 @@ pub enum Register {
     DeviceRevisionNo = 0x3E,
     /// Device ID
     DeviceId = 0x3F,
+    /// DAC Dither
+    DacDither = 0x41,
     /// ALC Enhancements 1
     AlcEnhancements1 = 0x46,
     /// ALC Enhancements 2
@@ -1187,6 +1189,27 @@ bitfield! {
     pub device_id, _: 8, 0;
 }
 
+bitfield! {
+    /// DAC Dither
+    ///
+    /// See [`read_dacdither`](crate::Codec::read_dacdither),
+    /// [`write_dacdither`](crate::Codec::write_dacdither) and
+    /// [`modify_dacdither`](crate::Codec::modify_dacdither)
+    pub struct DacDither(u16);
+    impl Debug;
+    u8;
+    /// Dither added to DAC modulator to eliminate all non-random noise
+    ///
+    /// * `0b00000` = dither off
+    /// * `0b10001` = nominal optimal dither
+    /// * `0b11111` = maximum dither
+    pub mod_dither, set_mod_dither: 8, 4;
+    /// Dither added to DAC analog output to eliminate all non-random noise
+    ///
+    /// * `0b0000` = dither off
+    /// * `0b0100` = nominal optimal dither
+    /// * `0b1111` = maximum dither
+    pub analog_dither, set_analog_dither: 3, 0;
 }
 
 bitfield! {

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,0 +1,1016 @@
+//! Register constants for the NAU88C22
+//!
+//! See <https://www.nuvoton.com/export/resource-files/NAU8822DataSheetRev3.3.pdf>
+
+// SPDX-FileCopyrightText: 2023 Jonathan 'theJPster' Pallant <github@thejpster.org.uk>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use bitfield::bitfield;
+
+/// The list of registers on the chip
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Register {
+    /// Software Reset RESET (SOFTWARE)
+    SoftwareReset = 0x00,
+    /// Power Management 1
+    PowerManagement1 = 0x01,
+    /// Power Management 2
+    PowerManagement2 = 0x02,
+    /// Power Management 3
+    PowerManagement3 = 0x03,
+    /// Audio Interface
+    AudioInterface = 0x04,
+    /// Companding
+    Companding = 0x05,
+    /// Clock Control 1
+    ClockControl1 = 0x06,
+    /// Clock Control 2
+    ClockControl2 = 0x07,
+    /// GPIO
+    GPIO = 0x08,
+    /// Jack Detect 1
+    JackDetect1 = 0x09,
+    /// DAC Control
+    DACControl = 0x0A,
+    /// Left DAC Volume
+    LeftDACVolume = 0x0B,
+    /// Right DAC Volume
+    RightDACVolume = 0x0C,
+    /// Jack Detect 2
+    JackDetect2 = 0x0D,
+    /// ADC Control
+    ADCControl = 0x0E,
+    /// Left ADC Volume
+    LeftADCVolume = 0x0F,
+    /// Right ADC Volume
+    RightADCVolume = 0x10,
+    /// EQ1-high cutoff
+    EQ1HighCutoff = 0x12,
+    /// EQ2-peak 1
+    EQ2Peak1 = 0x13,
+    /// EQ3-peak 2
+    EQ3Peak2 = 0x14,
+    /// EQ4-peak 3
+    EQ4Peak3 = 0x15,
+    /// EQ5-low cutoff
+    EQ5LowCutoff = 0x16,
+    /// DAC Limiter 1
+    DACLimiter1 = 0x18,
+    /// DAC Limiter 2
+    DACLimiter2 = 0x19,
+    /// Notch Filter 1
+    NotchFilter1 = 0x1B,
+    /// Notch Filter 2
+    NotchFilter2 = 0x1C,
+    /// Notch Filter 3
+    NotchFilter3 = 0x1D,
+    /// Notch Filter 4
+    NotchFilter4 = 0x1E,
+    /// ALC Control 1
+    ALCControl1 = 0x20,
+    /// ALC Control 2
+    ALCControl2 = 0x21,
+    /// ALC Control 3
+    ALCControl3 = 0x22,
+    /// Noise Gate
+    NoiseGate = 0x23,
+    /// PLL N
+    PllN = 0x24,
+    /// PLL K 1
+    PllK1 = 0x25,
+    /// PLL K 2
+    PllK2 = 0x26,
+    /// PLL K 3
+    PllK3 = 0x27,
+    /// 3D control
+    ThreeDControl = 0x29,
+    /// Right Speaker Submix
+    RightSpeakerSubmix = 0x2B,
+    /// Input Control
+    InputControl = 0x2C,
+    /// Left Input PGA Gain
+    LeftInputPGAGain = 0x2D,
+    /// Right Input PGA Gain
+    RightInputPGAGain = 0x2E,
+    /// Left ADC Boost
+    LeftADCBoost = 0x2F,
+    /// Right ADC Boost
+    RightADCBoost = 0x30,
+    /// Output Control
+    OutputControl = 0x31,
+    /// Left Mixer
+    LeftMixer = 0x32,
+    /// Right Mixer
+    RightMixer = 0x33,
+    /// LHP Volume
+    LHPVolume = 0x34,
+    /// RHP Volume
+    RHPVolume = 0x35,
+    /// LSPKOUT Volume
+    LSPKOUTVolume = 0x36,
+    /// RSPKOUT Volume
+    RSPKOUTVolume = 0x37,
+    /// AUX2 Mixer
+    AUX2Mixer = 0x38,
+    /// AUX1 Mixer
+    AUX1Mixer = 0x39,
+    /// Power Management
+    PowerManagement = 0x3A,
+    /// Left Time Slot
+    LeftTimeSlot = 0x3B,
+    /// Misc
+    Misc = 0x3C,
+    /// Right Time Slot
+    RightTimeSlot = 0x3D,
+
+    /// Device Revision #
+    DeviceRevisionNo = 0x3E,
+    /// Device ID
+    DeviceId = 0x3F,
+    /// ALC Enhancements 1
+    AlcEnhancements1 = 0x46,
+    /// ALC Enhancements 2
+    AlcEnhancements2 = 0x47,
+    /// Misc Controls
+    MiscControls = 0x49,
+    /// Tie-Off Overrides
+    TieOffOverrides = 0x4A,
+    /// Power/Tie-off Ctrl
+    PowerTieOffCtrl = 0x4B,
+    /// P2P Detector Read
+    P2PDetectorRead = 0x4C,
+    /// Peak Detector Read
+    PeakDetectorRead = 0x4D,
+    /// Control and Status
+    ControlAndStatus = 0x4E,
+    /// Output tie-off control
+    OutputTieOffControl = 0x4F,
+}
+
+bitfield! {
+    /// Power Management 1 register contents
+    pub struct PowerManagement1(u16);
+    impl Debug;
+    u8;
+    /// Power control for internal tie-off buffer used in 1.5X boost conditions
+    ///
+    /// * `false` - internal buffer unpowered
+    /// * `true` - enabled
+    pub dcbufen, set_dcbufen: 8;
+    /// Power control for AUX1 MIXER supporting AUXOUT1 analog output
+    ///
+    /// * `false` - unpowered
+    /// * `true` - enabled
+    pub aux1mxen, set_aux1mxen: 7;
+    /// Power control for AUX2 MIXER supporting AUXOUT2 analog output
+    ///
+    /// * `false` - unpowered
+    /// * `true` - enabled
+    pub aux2mxen, set_aux2mxen: 6;
+    /// Power control for internal PLL
+    ///
+    /// * `false` - unpowered
+    /// * `true` - enabled
+    pub pllen, set_pllen: 5;
+    /// Power control for microphone bias buffer amplifier (MICBIAS output, pin#32)
+    ///
+    /// * `false` - unpowered and MICBIAS pin in high-Z condition
+    /// * `true` - enabled
+    pub micbiasen, set_micbiasen: 4;
+    /// Power control for internal analog bias buffers
+    ///
+    /// * `false` - unpowered
+    /// * `true` - enabled
+    pub abiasen, set_abiasen: 3;
+    /// Power control for internal tie-off buffer used in non-boost mode (-1.0x gain) conditions
+    ///
+    /// * `false` - internal buffer unpowered
+    /// * `true` - enabled
+    pub iobufen, set_iobufen: 2;
+    /// Select impedance of reference string used to establish VREF for internal bias buffers
+    ///
+    /// * `0` = off (input to internal bias buffer in high-Z floating condition)
+    /// * `1` = 80kΩ nominal impedance at VREF pin
+    /// * `2` = 300kΩ nominal impedance at VREF pin
+    /// * `3` = 3kΩ nominal impedance at VREF pin
+    pub refimp, set_refimp: 1,0;
+}
+
+bitfield! {
+    /// Power Management 2 register contents
+    pub struct PowerManagement2(u16);
+    impl Debug;
+    u8;
+    /// Right Headphone driver enable, RHP analog output, pin#29
+    ///
+    /// * `false` = RHP pin in high-Z condition
+    /// * `true` = enabled
+    pub rhpen, set_rhpen: 8;
+    /// Left Headphone driver enabled, LHP analog output pin#30
+    ///
+    /// * `false` = LHP pin in high-Z condition
+    /// * `true` = enabled
+    pub lhpen, set_lhpen: 7;
+    /// Sleep enable
+    ///
+    /// * `false` = device in normal operating mode
+    /// * `true` = device in low-power sleep condition
+    pub sleep, set_sleep: 6;
+    /// Right channel input mixer, RADC Mix/Boost stage power control
+    ///
+    /// * `false` = RADC Mix/Boost stage OFF
+    /// * `true` = RADC Mix/Boost stage ON
+    pub rbsten, set_rbsten: 5;
+    /// Left channel input mixer, LADC Mix/Boost stage power control
+    ///
+    /// * `false` = LADC Mix/Boost stage OFF
+    /// * `true` = LADC Mix/Boost stage ON
+    pub lbsten, set_lbsten: 4;
+    /// Right channel input programmable amplifier (PGA) power control
+    ///
+    /// * `false` = Right PGA input stage OFF
+    /// * `true` = enabled
+    pub rpgaen, set_rpgaen: 3;
+    /// Left channel input programmable amplifier power control
+    ///
+    /// * `false` = Left PGA input stage OFF
+    /// * `true` = enabled
+    pub lpgaen, set_lpgaen: 2;
+    /// Right channel analog-to-digital converter power control
+    ///
+    /// * `false` = Right ADC stage OFF
+    /// * `true` = enabled
+    pub radcen, set_radcen: 1;
+    /// Left channel analog-to-digital converter power control
+    ///
+    /// * `false` = Left ADC stage OFF
+    /// * `true` = enable
+    pub ladcen, set_ladcen: 0;
+}
+
+bitfield! {
+    /// Power Management 3 register contents
+    pub struct PowerManagement3(u16);
+    impl Debug;
+    /// AUXOUT1 analog output power control, pin#21
+    ///
+    /// * `false` = AUXOUT1 output driver OFF
+    /// * `true` = enabled
+    pub auxout1en, set_auxout1en: 8;
+    /// AUXOUT2 analog output power control, pin#22
+    ///
+    /// * `false` = AUXOUT2 output driver OFF
+    /// * `true` = enabled
+    pub auxout2en, set_auxout2en: 7;
+    /// LSPKOUT left speaker driver power control, pin#25
+    ///
+    /// * `false` = LSPKOUT output driver OFF
+    /// * `true` = enabled
+    pub lspken, set_lspken: 6;
+    /// RSPKOUT left speaker driver power control, pin#23
+    ///
+    /// * `false` = RSPKOUT output driver OFF
+    /// * `true` = enabled
+    pub rspken, set_rspken: 5;
+    /// Right main mixer power control, RMAIN MIXER internal stage
+    ///
+    /// * `false` = RMAIN MIXER stage OFF
+    /// * `true` = enabled
+    pub rmixen, set_rmixen: 3;
+    /// Left main mixer power control, LMAIN MIXER internal stage
+    ///
+    /// * `false` = LMAIN MIXER stage OFF
+    /// * `true` = enabled
+    pub lmixen, set_lmixen: 2;
+    /// Right channel digital-to-analog converter, RDAC, power control
+    ///
+    /// * `false` = RDAC stage OFF
+    /// * `true` = enabled
+    pub rdacen, set_rdacen: 1;
+    /// Left channel digital-to-analog converter, LDAC, power control
+    ///
+    /// * `false` = LDAC stage OFF
+    /// * `true` = enabled
+    pub ldacen, set_ldacen: 0;
+}
+
+bitfield! {
+    /// Audio Interface register contents
+    pub struct AudioInterface(u16);
+    impl Debug;
+    u8;
+    /// Bit clock phase inversion option for BCLK, pin#8
+    ///
+    /// * `false` = normal phase
+    /// * `true` = input logic sense inverted
+    pub bclkp, set_bclkp: 8;
+    /// Phase control for I2S audio data bus interface, or PCMA and PCMB
+    /// left/right word order control
+    ///
+    /// * `false` = normal phase operation, or MSB is valid on 2nd rising edge
+    /// of BCLK after rising edge of FS
+    /// * `true` = inverted phase operation, or MSB is valid on 1st rising edge
+    /// of BCLK after rising edge of FS
+    pub lrp, set_lrp: 7;
+    /// Word length (24-bits default) of audio data stream
+    ///
+    /// * `00` = 16-bit word length
+    /// * `01` = 20-bit word length
+    /// * `10` = 24-bit word length
+    /// * `11` = 32-bit word length
+    pub wlen, set_wlen: 6,5;
+    /// Audio interface data format (default setting is I2S)
+    ///
+    /// * `00` = right justified
+    /// * `01` = left justified
+    /// * `10` = standard I2S format
+    /// * `11` = PCMA or PCMB audio data format option
+    pub aifmt, set_aifmt: 4,3;
+    /// DAC audio data left-right ordering
+    ///
+    /// * `false` = left DAC data in left phase of LRP
+    /// * `true` = left DAC data in right phase of LRP (left-right reversed)
+    pub dacphs, set_dacphs: 2;
+    /// ADC audio data left-right ordering
+    ///
+    /// * `false` = left ADC data is output in left phase of LRP
+    /// * `true` = left ADC data is output in right phase of LRP (left-right reversed)
+    pub adcphs, set_adcphs: 1;
+    /// Mono operation enable
+    ///
+    /// * `false` = normal stereo mode of operation
+    /// * `true` = mono mode with audio data in left phase of LRP
+    pub mono, set_mono: 0;
+}
+
+/// Whether 8-bit companding is enabled
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CompandingMode {
+    /// Companding is off
+    Off = 0,
+    /// Companding is on, and using µ-law
+    ULaw = 2,
+    /// Companding is on, and using A-law
+    ALaw = 3,
+}
+
+impl From<u8> for CompandingMode {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => CompandingMode::Off,
+            2 => CompandingMode::ULaw,
+            3 => CompandingMode::ALaw,
+            _ => unreachable!(),
+        }
+    }
+}
+
+bitfield! {
+    /// Companding register contents
+    pub struct Companding(u16);
+    impl Debug;
+    u8;
+    /// 8-bit word enable for companding mode of operation
+    ///
+    /// * `false` = normal operation (no companding)
+    /// * `true` = 8-bit operation for companding mode
+    pub cmb8, set_cmb8: 5;
+    /// DAC companding mode control
+    ///
+    /// * `0` = off (normal linear operation)
+    /// * `1` = reserved
+    /// * `2` = u-law companding
+    /// * `3` = A-law companding
+    pub daccm, set_daccm: 4, 3;
+    /// ADC companding mode control
+    ///
+    /// * `0` = off (normal linear operation)
+    /// * `1` = reserved
+    /// * `2` = u-law companding
+    /// * `3` = A-law companding
+    pub into CompandingMode, adccm, set_adccm: 2, 1;
+    /// DAC audio data input option to route directly to ADC data stream
+    ///
+    /// * `false` = no passthrough, normal operation
+    /// * `true` = ADC output data stream routed to DAC input data path
+    pub addap, set_addap: 0;
+}
+
+bitfield! {
+    /// Clock Control 1 register contents
+    pub struct ClockControl1(u16);
+    impl Debug;
+    u8;
+    /// Master clock source selection control
+    ///
+    /// * `false` = MCLK, pin#11 used as master clock
+    /// * `true` = internal PLL oscillator output used as master clock
+    pub clkm, set_clkm: 8;
+    /// Scaling of master clock source for internal 256fs rate (divide by 2 = default)
+    ///
+    /// * `0` = divide by 1
+    /// * `1` = divide by 1.5
+    /// * `2` = divide by 2
+    /// * `3` = divide by 3
+    /// * `4` = divide by 4
+    /// * `5` = divide by 6
+    /// * `6` = divide by 8
+    /// * `7` = divide by 12
+    pub mclksel, set_mclksel: 7, 5;
+    /// Scaling of output frequency at BCLK pin#8 when chip is in master mode
+    /// `0` = divide by 1
+    /// `1` = divide by 2
+    /// `2` = divide by 4
+    /// `3` = divide by 8
+    /// `4` = divide by 16
+    /// `5` = divide by 32
+    pub bclksel, set_bclksel: 4, 2;
+    /// Enables chip master mode to drive FS and BCLK outputs
+    ///
+    /// `false` = FS and BCLK are inputs
+    /// `true` = FS and BCLK are driven as outputs by internally generated clocks
+    pub clkioen, set_clkioen: 0;
+}
+
+bitfield! {
+    /// Clock Control 2 register contents
+    pub struct ClockControl2(u16);
+    impl Debug;
+    /// 4-wire control interface enable
+    ///
+    /// * `false` = disabled
+    /// * `true` = enabled
+    pub fourwirecie, set_fourwirecie: 8;
+    /// Audio data sample rate indication (48kHz default). Sets up scaling for
+    /// internal filter coefficients, but does not affect in any way the actual
+    /// device sample rate. Should be set to value most closely matching the
+    /// actual sample rate determined by 256fs internal node.
+    ///
+    /// * `0` = 48kHz
+    /// * `1` = 32kHz
+    /// * `2` = 24kHz
+    /// * `3` = 16kHz
+    /// * `4` = 12kHz
+    /// * `5` = 8kHz
+    /// * `6` = reserved
+    /// * `7` = reserved
+    pub smplr, set_smplr: 3, 1;
+    /// Slow timer clock enable. Starts internal timer clock derived by dividing
+    /// master clock.
+    ///
+    /// * `false` = disabled
+    /// * `true` = enabled
+    pub sclken, set_sclken: 0;
+}
+
+/// The operating modes CSB/GPIO1 can be in
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Gpio1Selection {
+    /// use as input subject to MODE pin#18 input logic level
+    Input = 0,
+    /// Temperature OK status output (logic 0 = thermal shutdown)
+    TemperatureOk = 2,
+    /// DAC automute condition (logic 1 = one or both DACs automuted)
+    DacIsAutomute = 3,
+    /// output divided PLL clock
+    PllClock = 4,
+    /// PLL locked condition (logic 1 = PLL locked)
+    PllLocked = 5,
+    /// output set to logic 1 condition
+    LogicHigh = 6,
+    /// output set to logic 0 condition
+    LogicLow = 7,
+}
+
+impl From<u8> for Gpio1Selection {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => Gpio1Selection::Input,
+            2 => Gpio1Selection::TemperatureOk,
+            3 => Gpio1Selection::DacIsAutomute,
+            4 => Gpio1Selection::PllClock,
+            5 => Gpio1Selection::PllLocked,
+            6 => Gpio1Selection::LogicHigh,
+            7 => Gpio1Selection::LogicLow,
+            _ => unreachable!(),
+        }
+    }
+}
+
+bitfield! {
+    /// GPIO register contents
+    pub struct GPIO(u16);
+    impl Debug;
+    u8;
+    /// Clock divisor applied to PLL clock for output from a GPIO pin
+    ///
+    /// * `0` = divide by 1
+    /// * `1` = divide by 2
+    /// * `2` = divide by 3
+    /// * `3` = divide by 4
+    pub gpio1pll, set_gpio1pll: 5, 4;
+    /// GPIO1 polarity inversion control
+    ///
+    /// * `0` = normal logic sense of GPIO signal
+    /// * `1` = inverted logic sense of GPIO signal
+    pub gpio1pl, set_gpio1pl: 3;
+    /// CSB/GPIO1 function select (input default)
+    ///
+    /// * `0` = use as input subject to MODE pin#18 input logic level
+    /// * `1` = reserved
+    /// * `2` = Temperature OK status output (logic 0 = thermal shutdown)
+    /// * `3` = DAC automute condition (logic 1 = one or both DACs automuted)
+    /// * `4` = output divided PLL clock
+    /// * `5` = PLL locked condition (logic 1 = PLL locked)
+    /// * `6` = output set to logic 1 condition
+    /// * `7` = output set to logic 0 condition
+    pub into Gpio1Selection, gpio1sel, set_gpio1sel: 2, 0;
+}
+
+bitfield! {
+    /// Jack Detect 1 register contents
+    pub struct JackDetect1(u16);
+    impl Debug;
+    u8;
+    /// Automatically enable internal bias amplifiers on jack detection state as
+    /// sensed through GPIO pin associated to jack detection function
+    ///
+    /// * `0` = disabled
+    /// * `1` = enable bias amplifiers on jack at logic 0 level
+    /// * `2` = enable bias amplifiers on jack at logic 1 level
+    /// * `3` = reserved
+    pub jckmiden, set_jckmiden: 8, 7;
+    /// Jack detection feature enable
+    ///
+    /// `false` = disabled
+    /// `true` = enable jack detection associated functionality
+    pub jacden, set_jacden: 6;
+    /// Select jack detect pin (GPIO1 default)
+    ///
+    /// `0` = GPIO1 is used for jack detection feature
+    /// `1` = GPIO2 is used for jack detection feature
+    /// `2` = GPIO3 is used for jack detection feature
+    /// `3` = reserved
+    pub jckdio, set_jckdio: 5, 4;
+}
+
+bitfield! {
+    /// DAC Control register contents
+    pub struct DACControl(u16);
+    impl Debug;
+    u8;
+    /// Softmute feature control for DACs
+    ///
+    /// `false` = disabled
+    /// `true` = enabled
+    pub softmt, set_softmt: 6;
+    /// DAC oversampling rate selection (64X default)
+    ///
+    /// `false` = 64x oversampling
+    /// `true` = 128x oversampling
+    pub dacos, set_dacos: 3;
+    /// DAC automute function enable
+    ///
+    /// `false` = disabled
+    /// `true` = enabled
+    pub automt, set_automt: 2;
+    /// DAC right channel output polarity control
+    ///
+    /// `false` = normal polarity
+    /// `true` = inverted polarity
+    pub rdacpl, set_rdacpl: 1;
+    /// DAC left channel output polarity control
+    ///
+    /// `false` = normal polarity
+    /// `true` = inverted polarity
+    pub ldacpl, set_ldacpl: 0;
+}
+
+bitfield! {
+    /// Left DAC Volume register contents
+    pub struct LeftDACVolume(u16);
+    impl Debug;
+    u8;
+    /// DAC volume update bit feature. Write-only bit for synchronized L/R DAC
+    /// changes
+    ///
+    /// * `false` = on R11 write, new R11 value stored in temporary register
+    /// * `true` = on R11 write, new R11 and pending R12 values become active
+    pub _, set_ldacvu: 8;
+    /// DAC left digital volume control (0dB default attenuation value).
+    /// Expressed as an attenuation value in 0.5dB steps as follows:
+    ///
+    /// * `0` = digital mute condition
+    /// * `1` = -127.0dB (highly attenuated)
+    /// * `2` = -126.5dB attenuation
+    /// * all intermediate 0.5 step values through to maximum
+    /// * `254` = -0.5dB attenuation
+    /// * `255` = 0.0dB attenuation (no attenuation
+    pub ldacgain, set_ldacgain: 7, 0;
+}
+
+bitfield! {
+    /// Right DAC Volume register contents
+    pub struct RightDACVolume(u16);
+    impl Debug;
+    /// DAC volume update bit feature. Write-only bit for synchronized L/R DAC
+    /// changes
+    ///
+    /// * `false` = on R12 write, new R12 value stored in temporary register
+    /// * `true` = on R12 write, new R12 and pending R12 values become active
+    pub _, set_rdacvu: 8;
+    /// DAC right digital volume control (0dB default attenuation value).
+    /// Expressed as an attenuation value in 0.5dB steps as follows:
+    ///
+    /// * `0` = digital mute condition
+    /// * `1` = -127.0dB (highly attenuated)
+    /// * `2` = -126.5dB attenuation
+    /// * all intermediate 0.5 step values through to maximum
+    /// * `254` = -0.5dB attenuation
+    /// * `255` = 0.0dB attenuation (no attenuation
+    pub rdacgain, set_rdacgain: 7, 0;
+}
+
+bitfield! {
+    /// Jack Detect 2 register contents
+    pub struct JackDetect2(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// ADC Control register contents
+    pub struct ADCControl(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Left ADC Volume register contents
+    pub struct LeftADCVolume(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Right ADC Volume register contents
+    pub struct RightADCVolume(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// EQ1-high cutoff register contents
+    pub struct EQ1HighCutoff(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// EQ2-peak 1 register contents
+    pub struct EQ2Peak1(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// EQ3-peak 2 register contents
+    pub struct EQ3Peak2(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// EQ4-peak 3 register contents
+    pub struct EQ4Peak3(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// EQ5-low cutoff register contents
+    pub struct EQ5LowCutoff(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// DAC Limiter 1 register contents
+    pub struct DACLimiter1(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// DAC Limiter 2 register contents
+    pub struct DACLimiter2(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Notch Filter 1 register contents
+    pub struct NotchFilter1(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Notch Filter 2 register contents
+    pub struct NotchFilter2(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Notch Filter 3 register contents
+    pub struct NotchFilter3(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Notch Filter 4 register contents
+    pub struct NotchFilter4(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// ALC Control 1 register contents
+    pub struct ALCControl1(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// ALC Control 2 register contents
+    pub struct ALCControl2(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// ALC Control 3 register contents
+    pub struct ALCControl3(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Noise Gate register contents
+    pub struct NoiseGate(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// PLL N register contents
+    pub struct PllN(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// PLL K 1 register contents
+    pub struct PllK1(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// PLL K 2 register contents
+    pub struct PllK2(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// PLL K 3 register contents
+    pub struct PllK3(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// 3D control register contents
+    pub struct ThreeDControl(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Right Speaker Submix register contents
+    pub struct RightSpeakerSubmix(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Input Control register contents
+    pub struct InputControl(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Left Input PGA Gain register contents
+    pub struct LeftInputPGAGain(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Right Input PGA Gain register contents
+    pub struct RightInputPGAGain(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Left ADC Boost register contents
+    pub struct LeftADCBoost(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Right ADC Boost register contents
+    pub struct RightADCBoost(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Output Control register contents
+    pub struct OutputControl(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Left Mixer register contents
+    pub struct LeftMixer(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Right Mixer register contents
+    pub struct RightMixer(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// LHP Volume register contents
+    pub struct LHPVolume(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// RHP Volume register contents
+    pub struct RHPVolume(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// LSPKOUT Volume register contents
+    pub struct LSPKOUTVolume(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// RSPKOUT Volume register contents
+    pub struct RSPKOUTVolume(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// AUX2 Mixer register contents
+    pub struct AUX2Mixer(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// AUX1 Mixer register contents
+    pub struct AUX1Mixer(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Power Management register contents
+    pub struct PowerManagement(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Left Time Slot register contents
+    pub struct LeftTimeSlot(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Misc register contents
+    pub struct Misc(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Right Time Slot register contents
+    pub struct RightTimeSlot(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Device Revision # register contents
+    pub struct DeviceRevisionNo(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Device ID register contents
+    pub struct DeviceId(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// ALC Enhancements 1 register contents
+    pub struct AlcEnhancements1(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// ALC Enhancements 2 register contents
+    pub struct AlcEnhancements2(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Misc Controls register contents
+    pub struct MiscControls(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Tie-Off Overrides register contents
+    pub struct TieOffOverrides(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Power/Tie-off Ctrl register contents
+    pub struct PowerTieOffCtrl(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// P2P Detector Read register contents
+    pub struct P2PDetectorRead(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Peak Detector Read register contents
+    pub struct PeakDetectorRead(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Control and Status register contents
+    pub struct ControlAndStatus(u16);
+    impl Debug;
+
+}
+
+bitfield! {
+    /// Output tie-off control register contents
+    pub struct OutputTieOffControl(u16);
+    impl Debug;
+
+}
+
+// End of file

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1158,80 +1158,416 @@ bitfield! {
 }
 
 bitfield! {
-    /// Device Revision # register contents
+    /// Device Revision register contents
+    ///
+    /// See [`read_devicerevisionno`](crate::Codec::read_devicerevisionno),
+    /// [`write_devicerevisionno`](crate::Codec::write_devicerevisionno) and
+    /// [`modify_devicerevisionno`](crate::Codec::modify_devicerevisionno)
     pub struct DeviceRevisionNo(u16);
     impl Debug;
-
+    u8;
+    /// Chip Revision.
+    ///
+    /// * Will be `0x7F` for Revision A.
+    pub revision, _: 7, 0;
 }
 
 bitfield! {
     /// Device ID register contents
+    ///
+    /// See [`read_deviceid`](crate::Codec::read_deviceid),
+    /// [`write_deviceid`](crate::Codec::write_deviceid) and
+    /// [`modify_deviceid`](crate::Codec::modify_deviceid)
     pub struct DeviceId(u16);
     impl Debug;
+    u16;
+    /// Device ID.
+    ///
+    /// Will be `0x01A`
+    pub device_id, _: 8, 0;
+}
 
 }
 
 bitfield! {
     /// ALC Enhancements 1 register contents
+    ///
+    /// See [`read_alcenhancements1`](crate::Codec::read_alcenhancements1),
+    /// [`write_alcenhancements1`](crate::Codec::write_alcenhancements1) and
+    /// [`modify_alcenhancements1`](crate::Codec::modify_alcenhancements1)
     pub struct AlcEnhancements1(u16);
     impl Debug;
-
+    u8;
+    /// Selects one of two tables used to set the target level for the ALC
+    ///
+    /// * `false` = default recommended target level table spanning -1.5dB through
+    /// -22.5dB FS
+    /// * `true` = optional ALC target level table spanning -6.0dB through -28.5dB
+    ///   FS
+    pub alctblsel, set_alctblsel: 8;
+    /// Choose peak or peak-to-peak value for ALC threshold logic
+    ///
+    /// * `false` = use rectified peak detector output value
+    /// * `true` = use peak-to-peak detector output value
+    pub alcpksel, set_alcpksel: 7;
+    /// Choose peak or peak-to-peak value for Noise Gate threshold logic
+    ///
+    /// * `false` = use rectified peak detector output value
+    /// * `true` = use peak-to-peak detector output value
+    pub alcngsel, set_alcngsel: 6;
+    /// Real time readout of instantaneous gain value used by left channel PGA
+    pub alcgainl, _: 5, 0;
 }
 
 bitfield! {
     /// ALC Enhancements 2 register contents
+    ///
+    /// See [`read_alcenhancements2`](crate::Codec::read_alcenhancements2),
+    /// [`write_alcenhancements2`](crate::Codec::write_alcenhancements2) and
+    /// [`modify_alcenhancements2`](crate::Codec::modify_alcenhancements2)
     pub struct AlcEnhancements2(u16);
     impl Debug;
-
+    u8;
+    /// Enable control for ALC fast peak limiter function
+    ///
+    /// * `false` = enabled (default)
+    /// * `true` = disabled
+    pub pklimena, set_pklimena: 8;
+    /// Real time readout of instantaneous gain value used by right channel PGA
+    pub alcgainl, _: 5, 0;
 }
 
 bitfield! {
     /// Misc Controls register contents
+    ///
+    /// See [`read_misccontrols`](crate::Codec::read_misccontrols),
+    /// [`write_misccontrols`](crate::Codec::write_misccontrols) and
+    /// [`modify_misccontrols`](crate::Codec::modify_misccontrols)
     pub struct MiscControls(u16);
     impl Debug;
-
+    u8;
+    /// Set SPI control bus mode regardless of state of Mode pin
+    ///
+    /// * `false` = normal operation (default)
+    /// * `true` = force SPI 4-wire mode regardless of state of Mode pin
+    pub fwspiena, set_fwspiena: 8;
+    /// Short frame sync detection period value
+    ///
+    /// * `0` = trigger if frame time less than 255 MCLK edges
+    /// * `1` = trigger if frame time less than 253 MCLK edges
+    /// * `2` = trigger if frame time less than 254 MCLK edges
+    /// * `3` = trigger if frame time less than 255 MCLK edges
+    pub fserrval, set_fserrval: 7, 6;
+    /// Enable DSP state flush on short frame sync event
+    ///
+    /// * `false` = ignore short frame sync events (default)
+    /// * `true` = set DSP state to initial conditions on short frame sync event
+    pub fserflsh, set_fserflsh: 5;
+    /// Enable control for short frame cycle detection logic
+    ///
+    /// * `false` = short frame cycle detection logic enabled
+    /// * `true` = short frame cycle detection logic disabled
+    pub fserrena, set_fserrena: 4;
+    /// Enable control to delay use of notch filter output when filter is
+    /// enabled
+    ///
+    /// * `false` = delay using notch filter output 512 sample times after notch
+    ///   enabled (default)
+    /// * `true` = use notch filter output immediately after notch filter is
+    ///   enabled
+    pub notchdly, set_notchdly: 3;
+    /// Enable control to mute DAC limiter output when softmute is enabled
+    ///
+    /// * `false` = DAC limiter output may not move to exactly zero during Softmute
+    ///   (default)
+    /// * `true` = DAC limiter output muted to exactly zero during softmute
+    pub dacinmute, set_dacinmute: 2;
+    /// Enable control to use PLL output when PLL is not in phase locked
+    /// condition
+    ///
+    /// * `false` = PLL VCO output disabled when PLL is in unlocked condition
+    ///   (default)
+    /// * `true` = PLL VCO output used as-is when PLL is in unlocked condition
+    pub plllockbp, set_plllockbp: 1;
+    /// Set DAC to use 256x oversampling rate (best at lower sample rates)
+    ///
+    /// * `false` = Use oversampling rate as determined by Register 0x0A[3]
+    ///   (default)
+    /// * `true` = Set DAC to 256x oversampling rate regardless of Register 0x0A[3]
+    pub dacosr256, set_dacosr256: 0;
 }
 
 bitfield! {
     /// Tie-Off Overrides register contents
+    ///
+    /// See [`read_tieoffoverrides`](crate::Codec::read_tieoffoverrides),
+    /// [`write_tieoffoverrides`](crate::Codec::write_tieoffoverrides) and
+    /// [`modify_tieoffoverrides`](crate::Codec::modify_tieoffoverrides)
     pub struct TieOffOverrides(u16);
     impl Debug;
-
+    u8;
+    /// Enable direct control over input tie-off resistor switching
+    ///
+    /// * `false` = ignore Register 0x4A bits to control input tie-off resistor
+    ///   switching
+    /// * `true` = use Register 0x4A bits to override automatic tie-off resistor
+    ///   switching
+    pub maninena, set_maninena: 8;
+    /// If MANUINEN = 1, use this bit to control right aux input tie-off
+    /// resistor switch
+    ///
+    /// * `false` = Tie-off resistor switch for RAUXIN input is forced open
+    /// * `true` = Tie-off resistor switch for RAUXIN input is forced closed
+    pub manraux, set_manraux: 7;
+    /// If MANUINEN = 1, use this bit to control right line input tie-off
+    /// resistor switch
+    ///
+    /// * `false` = Tie-off resistor switch for RLIN input is forced open
+    /// * `true` = Tie-off resistor switch for RLIN input is forced closed
+    pub manrlin, set_manrlin: 6;
+    /// If MANUINEN = 1, use this bit to control right PGA inverting input
+    /// tie-off switch
+    ///
+    /// * `false` = Tie-off resistor switch for RMICN input is forced open
+    /// * `true` = Tie-off resistor switch for RMICN input is forced closed
+    pub manrmicn, set_manrmicn: 5;
+    /// If MANUINEN =1, use this bit to control right PGA non-inverting input
+    /// tie-off switch
+    ///
+    /// * `false` = Tie-off resistor switch for RMICP input is forced open
+    /// * `true` = Tie-off resistor switch for RMICP input is forced closed
+    pub manrmicp, set_manrmicp: 4;
+    /// If MANUINEN = 1, use this bit to control left aux input tie-off resistor
+    /// switch
+    ///
+    /// * `false` = Tie-off resistor switch for LAUXIN input is forced open
+    /// * `true` = Tie-off resistor switch for RAUXIN input is forced closed
+    pub manlaux, set_manlaux: 3;
+    /// If MANUINEN = 1, use this bit to control left line input tie-off
+    /// resistor switch
+    ///
+    /// * `false` = Tie-off resistor switch for LLIN input is forced open
+    /// * `true` = Tie-off resistor switch for LLIN input is forced closed
+    pub manllin, set_manllin: 2;
+    /// If MANUINEN = 1, use this bit to control left PGA inverting input
+    /// tie-off switch
+    ///
+    /// * `false` = Tie-off resistor switch for LMICN input is forced open
+    /// * `true` = Tie-off resistor switch for LMINN input is forced closed
+    pub manlmicn, set_manlmicn: 1;
+    /// If MANUINEN = 1, use this bit to control left PGA non-inverting input
+    /// tie-off switch
+    ///
+    /// * `false` = Tie-off resistor switch for LMICP input is forced open
+    /// * `true` = Tie-off resistor switch for LMICP input is forced closed
+    pub manlmicp, set_manlmicp: 0;
 }
 
 bitfield! {
     /// Power/Tie-off Ctrl register contents
+    ///
+    /// See [`read_powertieoffctrl`](crate::Codec::read_powertieoffctrl),
+    /// [`write_powertieoffctrl`](crate::Codec::write_powertieoffctrl) and
+    /// [`modify_powertieoffctrl`](crate::Codec::modify_powertieoffctrl)
     pub struct PowerTieOffCtrl(u16);
     impl Debug;
-
+    u8;
+    /// Reduce bias current to left and right input MIX/BOOST stage
+    ///
+    /// * `false` = normal bias current
+    /// * `true` = bias current reduced by 50% for reduced power and bandwidth
+    pub ibthalfi, set_ibthalfi: 8;
+    /// Increase bias current to left and right input MIX/BOOST stage
+    ///
+    /// * `false` = normal bias current
+    /// * `true` = bias current increased by 500 microamps
+    pub ibt500up, set_ibt500up: 6;
+    /// Decrease bias current to left and right input MIX/BOOST stage
+    ///
+    /// * `false` = normal bias current
+    /// * `true` = bias current reduced by 250 microamps
+    pub ibt250dn, set_ibt250dn: 5;
+    /// Direct manual control to turn on bypass switch around input tie-off
+    /// buffer amplifier
+    ///
+    /// * `false` = normal automatic operation of bypass switch
+    /// * `true` = bypass switch in closed position when input buffer amplifier is
+    ///   disabled
+    pub maninbbp, set_maninbbp: 4;
+    /// Direct manual control to turn on switch to ground at input tie-off
+    /// buffer amp output
+    ///
+    /// * `false` = normal automatic operation of switch to ground
+    /// * `true` = switch to ground in in closed position when input buffer
+    ///   amplifier is disabled
+    pub maninpad, set_maninpad: 3;
+    /// Direct manual control of switch for Vref 600k-ohm resistor to ground
+    ///
+    /// * `false` = switch to ground controlled by Register 0x01 setting
+    /// * `true` = switch to ground in the closed position
+    pub manvrefh, set_manvrefh: 2;
+    /// Direct manual control for switch for Vref 160k-ohm resistor to ground
+    ///
+    /// * `false` = switch to ground controlled by Register 0x01 setting
+    /// * `true` = switch to ground in the closed position
+    pub manvrefm, set_manvrefm: 1;
+    /// Direct manual control for switch for Vref 6k-ohm resistor to ground
+    ///
+    /// * `false` = switch to ground controlled by Register 0x01 setting
+    /// * `true` = switch to ground in the closed position
+    pub manvrefl, set_manvrefl: 0;
 }
 
 bitfield! {
     /// P2P Detector Read register contents
+    ///
+    /// See [`read_p2pdetectorread`](crate::Codec::read_p2pdetectorread),
+    /// [`write_p2pdetectorread`](crate::Codec::write_p2pdetectorread) and
+    /// [`modify_p2pdetectorread`](crate::Codec::modify_p2pdetectorread)
     pub struct P2PDetectorRead(u16);
     impl Debug;
-
+    u16;
+    /// Read-only register which outputs the instantaneous value contained in
+    /// the peak-to-peak amplitude register used by the ALC for signal level
+    /// dependent logic. Value is highest of left or right input when both
+    /// inputs are under ALC control.
+    pub p2pval, _: 8, 0;
 }
 
 bitfield! {
     /// Peak Detector Read register contents
+    ///
+    /// See [`read_peakdetectorread`](crate::Codec::read_peakdetectorread),
+    /// [`write_peakdetectorread`](crate::Codec::write_peakdetectorread) and
+    /// [`modify_peakdetectorread`](crate::Codec::modify_peakdetectorread)
     pub struct PeakDetectorRead(u16);
     impl Debug;
-
+    /// Read-only register which outputs the instantaneous value contained in
+    /// the peak detector amplitude register used by the ALC for signal level
+    /// dependent logic. Value is highest of left or right input when both
+    /// inputs are under ALC control.
+    pub peakval, _: 8, 0;
 }
 
 bitfield! {
     /// Control and Status register contents
+    ///
+    /// See [`read_controlandstatus`](crate::Codec::read_controlandstatus),
+    /// [`write_controlandstatus`](crate::Codec::write_controlandstatus) and
+    /// [`modify_controlandstatus`](crate::Codec::modify_controlandstatus)
     pub struct ControlAndStatus(u16);
     impl Debug;
-
+    /// Select observation point used by DAC output automute feature
+    ///
+    /// * `false` = automute operates on data at the input to the DAC digital
+    ///   attenuator (default)
+    /// * `true` = automute operates on data at the DACIN input pin
+    pub amutctrl, set_amutctrl: 5;
+    /// Read-only status bit of high voltage detection circuit monitoring VDDSPK
+    /// voltage
+    ///
+    /// * `false` = voltage on VDDSPK pin measured at approximately 4.0Vdc or
+    ///   less
+    /// * `true` = voltage on VDDSPK pin measured at approximately 4.0Vdc or
+    ///   greater
+    pub hvdet, _: 4;
+    /// Read-only status bit of logic controlling the noise gate function
+    ///
+    /// * `false` = signal is greater than the noise gate threshold and ALC gain
+    ///   can change
+    /// * `true` = signal is less than the noise gate threshold and ALC gain is
+    ///   held constant
+    pub nsgate, _: 3;
+    /// Read-only status bit of analog mute function applied to DAC channels
+    ///
+    /// * `false` = not in the automute condition
+    /// * `true` = in automute condition
+    pub anamute, _: 2;
+    /// Read-only status bit of digital mute function of the left channel DAC
+    ///
+    /// * `false` = digital gain value is greater than zero
+    /// * `true` = digital gain is zero either by direct setting or operation of
+    ///   softmute function
+    pub digmutel, _: 1;
+    /// Read-only status bit of digital mute function of the left channel DAC
+    ///
+    /// * `false` = digital gain value is greater than zero
+    /// * `true` = digital gain is zero either by direct setting or operation of
+    ///   softmute function
+    pub digmuter, _: 0;
 }
 
 bitfield! {
     /// Output tie-off control register contents
+    ///
+    /// See
+    /// [`read_outputtieoffcontrol`](crate::Codec::read_outputtieoffcontrol),
+    /// [`write_outputtieoffcontrol`](crate::Codec::write_outputtieoffcontrol)
+    /// and
+    /// [`modify_outputtieoffcontrol`](crate::Codec::modify_outputtieoffcontrol)
     pub struct OutputTieOffControl(u16);
     impl Debug;
-
+    /// Enable direct control over output tie-off resistor switching
+    ///
+    /// * `false` = ignore Register 0x4F bits to control input tie-off
+    ///   resistor/buffer switching
+    /// * `true` = use Register 0x4F bits to override automatic tie-off
+    ///   resistor/buffer switching
+    pub manouten, set_manouten: 8;
+    /// If MANUOUTEN = 1, use this bit to control bypass switch around 1.5x
+    /// boosted output tie-off buffer amplifier
+    ///
+    /// * `false` = normal automatic operation of bypass switch
+    /// * `true` = bypass switch in closed position when output buffer amplifier
+    ///   is disabled
+    pub shrtbufh, set_shrtbufh: 7;
+    /// If MANUOUTEN = 1, use this bit to control bypass switch around 1.0x
+    /// non-boosted output tie-off buffer amplifier
+    ///
+    /// * `false` = normal automatic operation of bypass switch
+    /// * `true` = bypass switch in closed position when output buffer amplifier is
+    ///   disabled
+    pub shrtbufl, set_shrtbufl: 6;
+    /// If MANUOUTEN = 1, use this bit to control left speaker output tie-off
+    /// resistor switch
+    ///
+    /// * `false` = tie-off resistor switch for LSPKOUT speaker output is forced
+    ///   open
+    /// * `true` = tie-off resistor switch for LSPKOUT speaker output is forced
+    ///   closed
+    pub shrtlspk, set_shrtlspk: 5;
+    /// If MANUOUTEN = 1, use this bit to control left speaker output tie-off
+    /// resistor switch
+    ///
+    /// * `false` = tie-off resistor switch for RSPKOUT speaker output is forced
+    ///   open
+    /// * `true` = tie-off resistor switch for RSPKOUT speaker output is forced
+    ///   closed
+    pub shrtrspk, set_shrtrspk: 4;
+    /// If MANUOUTEN = 1, use this bit to control Auxout1 output tie-off
+    /// resistor switch
+    ///
+    /// * `false` = tie-off resistor switch for AUXOUT1 output is forced open
+    /// * `true` = tie-off resistor switch for AUXOUT1 output is forced closed
+    pub shrtaux1, set_shrtaux1: 3;
+    /// If MANUOUTEN = 1, use this bit to control Auxout2 output tie-off
+    /// resistor switch
+    ///
+    /// * `false` = tie-off resistor switch for AUXOUT2 output is forced open
+    /// * `true` = tie-off resistor switch for AUXOUT2 output is forced closed
+    pub shrtaux2, set_shrtaux2: 2;
+    /// If MANUOUTEN = 1, use this bit to control left headphone output tie-off
+    /// switch
+    ///
+    /// * `false` = tie-off resistor switch for LHP output is forced open
+    /// * `true` = tie-off resistor switch for LHP output is forced closed
+    pub shrtlhp, set_shrtlhp: 1;
+    /// If MANUOUTEN = 1, use this bit to control right headphone output tie-off
+    /// switch
+    ///
+    /// * `false` = tie-off resistor switch for RHP output is forced open
+    /// * `true` = tie-off resistor switch for RHP output is forced closed
+    pub shrtrhp, set_shrtrhp: 0;
 }
 
 // End of file


### PR DESCRIPTION
Adds methods to read or write every field in every register.

This was written by manually copy-pasting from the PDF (which does not lend itself to such activities, because the text is rendered out-of-order) so apologies for any mistakes.